### PR TITLE
[SHB-004] Feature: Add KHInsider Downloader Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ cover.jpg
 *.swo
 .idea/
 .vscode/
+
+# Local task notes
+/task.md
+/TASK.md
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- KHInsider support: download single tracks and full albums from
+  `downloads.khinsider.com` by resolving mirror links and converting via yt-dlp
+  (opus, flac, mp3, and other formats). Uses KHInsider album metadata and cover
+  art instead of Spotify/Last.fm lookups.
+- Download Log menu in the interactive console: view recent acquisition output,
+  persisted to `~/.config/shadowbox/download.log`.
+
+### Fixed
+- KHInsider tagging now reads artist, album, track, and disc metadata from tags
+  already embedded in mirror downloads (preserved by yt-dlp), instead of
+  scraping the album page. Cover art is still fetched from the KHInsider album
+  page when the audio file has none.
+
 ## [1.3.0] - 2026-06-26
 
 ### Added

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/EnJulian/shadowbox/internal/config"
 	"github.com/EnJulian/shadowbox/internal/cover"
 	"github.com/EnJulian/shadowbox/internal/download"
+	"github.com/EnJulian/shadowbox/internal/progress"
 )
 
 // App holds the configured clients used across the pipeline.
@@ -43,17 +44,25 @@ type Options struct {
 	Format     string // audio format; defaults to config
 	UseSpotify bool   // force Spotify metadata enrichment
 
-	// Progress, when set, receives short human-readable descriptions of each
-	// pipeline stage as it begins (e.g. "ripping audio", "writing tags"). It is
+	// Progress, when set, receives pipeline stage updates for the UI. It is
 	// called from the worker goroutine, so callers must keep the handler
 	// non-blocking and concurrency-safe. Optional.
-	Progress func(stage string)
+	Progress func(progress.Update)
 }
 
-// step reports a pipeline stage to the Progress handler when one is configured.
+// step reports a pipeline stage without numeric position.
 func (o Options) step(stage string) {
+	o.report(progress.Update{Stage: stage})
+}
+
+// stepN reports a numbered pipeline stage (1-based current).
+func (o Options) stepN(stage string, current, total int) {
+	o.report(progress.Update{Stage: stage, Current: current, Total: total})
+}
+
+func (o Options) report(u progress.Update) {
 	if o.Progress != nil {
-		o.Progress(stage)
+		o.Progress(u)
 	}
 }
 
@@ -73,5 +82,9 @@ func (a *App) musicDir(opts Options) string {
 
 // newDownloader builds a downloader for the effective format.
 func (a *App) newDownloader(opts Options) *download.Downloader {
-	return download.New(a.format(opts))
+	dl := download.New(a.format(opts))
+	if opts.Progress != nil {
+		dl.Progress = opts.Progress
+	}
+	return dl
 }

--- a/internal/app/enhance.go
+++ b/internal/app/enhance.go
@@ -66,7 +66,7 @@ func (a *App) EnhanceDir(ctx context.Context, dir string, recursive bool, exts [
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		opts.step(fmt.Sprintf("enhancing %d of %d: %s", i+1, len(files), filepath.Base(f)))
+		opts.stepN("enhancing", i+1, len(files))
 		if err := a.enhanceFile(ctx, f, "", "", opts); err != nil {
 			applog.Error("Failed to enhance %s: %v", filepath.Base(f), err)
 			continue

--- a/internal/app/khinsider.go
+++ b/internal/app/khinsider.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/EnJulian/shadowbox/internal/download"
+	applog "github.com/EnJulian/shadowbox/internal/log"
+	"github.com/EnJulian/shadowbox/internal/tag"
+)
+
+// khInsiderCover caches album cover bytes across a playlist run.
+type khInsiderCover struct {
+	data    []byte
+	mime    string
+	fetched bool
+}
+
+func (a *App) buildKHInsiderMetadataFromFile(ctx context.Context, file, albumURL string, opts Options, cover *khInsiderCover) (*tag.Metadata, error) {
+	opts.step("reading embedded KHInsider tags")
+	m, err := tag.Read(file)
+	if err != nil {
+		applog.Warningf("KHINSIDER", "Could not read embedded tags: %v", err)
+		m = &tag.Metadata{}
+	}
+	if m.Title == "" {
+		title, _ := parseFromFilename(file)
+		if title != "" {
+			m.Title = title
+		}
+	}
+	if m.Title == "" {
+		return nil, fmt.Errorf("no title in embedded tags or filename for %s", file)
+	}
+
+	if cover != nil {
+		cover.attach(ctx, albumURL, m, opts)
+	} else {
+		attachKHInsiderCover(ctx, albumURL, m, opts)
+	}
+	return m, nil
+}
+
+func attachKHInsiderCover(ctx context.Context, albumURL string, m *tag.Metadata, opts Options) {
+	if m.HasCover() || albumURL == "" {
+		return
+	}
+	opts.step("fetching KHInsider cover art")
+	album, err := download.FetchKHInsiderAlbumInfo(ctx, albumURL)
+	if err != nil {
+		applog.Warningf("KHINSIDER", "Album page fetch failed: %v", err)
+		return
+	}
+	if album.CoverURL == "" {
+		return
+	}
+	applog.Systemf("KHINSIDER", "Cover: %s", album.CoverURL)
+	data, mime, err := download.FetchKHCover(ctx, album.CoverURL)
+	if err != nil {
+		applog.Warningf("KHINSIDER", "Cover download failed: %v", err)
+		return
+	}
+	if len(data) > 0 {
+		m.Cover = data
+		m.CoverMIME = mime
+		applog.Success("KHInsider cover art embedded")
+	}
+}
+
+func (c *khInsiderCover) attach(ctx context.Context, albumURL string, m *tag.Metadata, opts Options) {
+	if m.HasCover() {
+		return
+	}
+	if c.fetched {
+		if len(c.data) > 0 {
+			m.Cover = c.data
+			m.CoverMIME = c.mime
+		}
+		return
+	}
+	c.fetched = true
+	attachKHInsiderCover(ctx, albumURL, m, opts)
+	c.data = m.Cover
+	c.mime = m.CoverMIME
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -53,7 +53,7 @@ func (a *App) Run(ctx context.Context, query string, opts Options) error {
 	} else {
 		meta = a.buildMetadata(ctx, file, query, opts)
 	}
-	useExternal := !(download.IsURL(query) && download.IsKHInsider(query))
+	useExternal := !download.IsURL(query) || !download.IsKHInsider(query)
 	final, err := a.finalize(ctx, file, meta, musicDir, opts, useExternal)
 	if err != nil {
 		return err

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -18,7 +18,7 @@ func (a *App) Run(ctx context.Context, query string, opts Options) error {
 	if missing := download.MissingRequired(); len(missing) > 0 {
 		return fmt.Errorf("missing required tools: %s (run 'shadowbox doctor')", strings.Join(missing, ", "))
 	}
-	if download.IsURL(query) && download.IsYouTubePlaylist(query) {
+	if download.IsURL(query) && (download.IsYouTubePlaylist(query) || download.IsKHInsiderPlaylist(query)) {
 		return a.RunPlaylist(ctx, query, opts)
 	}
 
@@ -44,8 +44,17 @@ func (a *App) Run(ctx context.Context, query string, opts Options) error {
 		return err
 	}
 
-	meta := a.buildMetadata(ctx, file, query, opts)
-	final, err := a.finalize(ctx, file, meta, musicDir, opts)
+	var meta *tag.Metadata
+	if download.IsURL(query) && download.IsKHInsider(query) {
+		meta, err = a.buildKHInsiderMetadataFromFile(ctx, file, download.KHInsiderAlbumURL(query), opts, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		meta = a.buildMetadata(ctx, file, query, opts)
+	}
+	useExternal := !(download.IsURL(query) && download.IsKHInsider(query))
+	final, err := a.finalize(ctx, file, meta, musicDir, opts, useExternal)
 	if err != nil {
 		return err
 	}
@@ -66,6 +75,9 @@ func (a *App) RunPlaylist(ctx context.Context, url string, opts Options) error {
 
 	opts.step("ripping playlist audio")
 	applog.Step("PLAYLIST", "Downloading playlist (this may take a while)")
+
+	khInsider := download.IsKHInsider(url)
+
 	files, err := dl.DownloadPlaylist(ctx, url, tmpDir)
 	if err != nil {
 		return err
@@ -75,10 +87,21 @@ func (a *App) RunPlaylist(ctx context.Context, url string, opts Options) error {
 	trackOpts.Output = ""
 
 	var ok int
+	var khCover khInsiderCover
 	for i, f := range files {
-		opts.step(fmt.Sprintf("processing track %d of %d", i+1, len(files)))
-		meta := a.buildMetadata(ctx, f, "", trackOpts)
-		if _, err := a.finalize(ctx, f, meta, musicDir, trackOpts); err != nil {
+		opts.stepN("processing track", i+1, len(files))
+		var meta *tag.Metadata
+		var err error
+		if khInsider {
+			meta, err = a.buildKHInsiderMetadataFromFile(ctx, f, url, trackOpts, &khCover)
+		} else {
+			meta = a.buildMetadata(ctx, f, "", trackOpts)
+		}
+		if err != nil {
+			applog.Error("Failed to build metadata for %s: %v", filepath.Base(f), err)
+			continue
+		}
+		if _, err := a.finalize(ctx, f, meta, musicDir, trackOpts, !khInsider); err != nil {
 			applog.Error("Failed to process %s: %v", filepath.Base(f), err)
 			continue
 		}
@@ -121,7 +144,7 @@ func (a *App) enhanceFile(ctx context.Context, path, title, artist string, opts 
 		Date:   existing.Date,
 	}, true, opts)
 
-	a.attachCoverAndLyrics(ctx, meta, opts)
+	a.attachCoverAndLyrics(ctx, meta, opts, true)
 	opts.step("writing tags")
 	if err := tag.Write(path, meta); err != nil {
 		return err
@@ -193,9 +216,10 @@ func (a *App) enrich(ctx context.Context, m *tag.Metadata, forceSpotify bool, op
 }
 
 // finalize organises the file into Artist/Album, embeds cover and lyrics, writes
-// tags, and returns the final path.
-func (a *App) finalize(ctx context.Context, srcFile string, meta *tag.Metadata, musicDir string, opts Options) (string, error) {
-	a.attachCoverAndLyrics(ctx, meta, opts)
+// tags, and returns the final path. When useExternalMeta is false, Spotify/Last.fm
+// cover and Genius lyrics are skipped (KHInsider supplies its own metadata).
+func (a *App) finalize(ctx context.Context, srcFile string, meta *tag.Metadata, musicDir string, opts Options, useExternalMeta bool) (string, error) {
+	a.attachCoverAndLyrics(ctx, meta, opts, useExternalMeta)
 
 	opts.step("organizing files")
 	artistDir, err := organize.ArtistDir(musicDir, meta.Artist)
@@ -226,17 +250,19 @@ func (a *App) finalize(ctx context.Context, srcFile string, meta *tag.Metadata, 
 }
 
 // attachCoverAndLyrics fills in cover image bytes and lyrics on the metadata.
-func (a *App) attachCoverAndLyrics(ctx context.Context, meta *tag.Metadata, opts Options) {
-	opts.step("fetching cover art")
-	if url := a.cover.URL(ctx, meta.Title, meta.Artist); url != "" {
-		if data, mime, err := a.cover.Download(ctx, url); err == nil && len(data) > 0 {
-			meta.Cover = data
-			meta.CoverMIME = mime
-			applog.Success("Cover art embedded")
+func (a *App) attachCoverAndLyrics(ctx context.Context, meta *tag.Metadata, opts Options, useExternalSources bool) {
+	if useExternalSources && !meta.HasCover() {
+		opts.step("fetching cover art")
+		if url := a.cover.URL(ctx, meta.Title, meta.Artist); url != "" {
+			if data, mime, err := a.cover.Download(ctx, url); err == nil && len(data) > 0 {
+				meta.Cover = data
+				meta.CoverMIME = mime
+				applog.Success("Cover art embedded")
+			}
 		}
 	}
 
-	if a.cfg.UseGenius && a.genius.Configured() {
+	if useExternalSources && a.cfg.UseGenius && a.genius.Configured() {
 		opts.step("fetching lyrics")
 		applog.Systemf("LYRICS", "Searching: %s by %s", meta.Title, meta.Artist)
 		if lyrics, err := a.genius.Lyrics(ctx, meta.Title, meta.Artist); err == nil && lyrics != "" {

--- a/internal/cmd/download.go
+++ b/internal/cmd/download.go
@@ -21,7 +21,7 @@ func newDownloadCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "download",
 		Short: "Download a track or playlist and tag it",
-		Long: "Download audio from a YouTube/Bandcamp URL or a search query, then\n" +
+		Long: "Download audio from a YouTube/Bandcamp/KHInsider URL or a search query, then\n" +
 			"organise and tag it with metadata, cover art, and lyrics.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if query == "" && len(args) > 0 {

--- a/internal/download/deps.go
+++ b/internal/download/deps.go
@@ -17,7 +17,7 @@ type Dependency struct {
 // current PATH.
 func Dependencies() []Dependency {
 	specs := []Dependency{
-		{Name: "yt-dlp", Purpose: "downloading audio from YouTube/Bandcamp", Required: true},
+		{Name: "yt-dlp", Purpose: "downloading audio from YouTube/Bandcamp/KHInsider", Required: true},
 		{Name: "ffmpeg", Purpose: "audio extraction and conversion", Required: true},
 		{Name: "aria2c", Purpose: "accelerated multi-connection downloads", Required: false},
 	}

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	applog "github.com/EnJulian/shadowbox/internal/log"
+	"github.com/EnJulian/shadowbox/internal/progress"
 )
 
 // audioExtensions are the output extensions yt-dlp may produce, in preference order.
@@ -23,6 +24,8 @@ type Downloader struct {
 	Format string
 	// UseAria2 enables the aria2c-accelerated strategy when aria2c is present.
 	UseAria2 bool
+	// Progress receives live download updates for the UI. Optional.
+	Progress func(progress.Update)
 }
 
 // New returns a Downloader for the given format, auto-detecting aria2c.
@@ -100,6 +103,62 @@ func (d *Downloader) strategies() []strategy {
 	return out
 }
 
+// directMediaStrategies returns yt-dlp strategies for already-resolved direct media
+// URLs (e.g. KHInsider mirror links).
+func (d *Downloader) directMediaStrategies() []strategy {
+	var out []strategy
+	if d.UseAria2 {
+		out = append(out, strategy{
+			name: "Direct aria2c",
+			args: func(format, output string) []string {
+				return []string{
+					"--downloader", "aria2c",
+					"--downloader-args", "aria2c:-x 16 -s 16 -j 16 --max-connection-per-server=16",
+					"-x",
+					"--embed-metadata",
+					"--audio-format", format,
+					"--retry-sleep", "1",
+					"--retries", "3",
+					"-o", output,
+				}
+			},
+		})
+	}
+	out = append(out,
+		strategy{
+			name: "Direct Standard",
+			args: func(format, output string) []string {
+				return []string{
+					"-x",
+					"--embed-metadata",
+					"--audio-format", format,
+					"--retry-sleep", "2",
+					"--retries", "5",
+					"--socket-timeout", "30",
+					"-o", output,
+				}
+			},
+		},
+		strategy{
+			name: "Direct Browser Simulation",
+			args: func(format, output string) []string {
+				return []string{
+					"--user-agent", khUserAgent,
+					"-x",
+					"--embed-metadata",
+					"--audio-format", format,
+					"--no-warnings",
+					"--retry-sleep", "3",
+					"--retries", "3",
+					"--socket-timeout", "45",
+					"-o", output,
+				}
+			},
+		},
+	)
+	return out
+}
+
 // fatalErrorPhrases indicate a video that no strategy can recover.
 var fatalErrorPhrases = []string{
 	"Video unavailable", "Private video", "This video is not available",
@@ -121,9 +180,20 @@ func (d *Downloader) Download(ctx context.Context, query, dir string) (string, e
 
 	target := query
 	switch {
+	case IsURL(query) && IsKHInsiderTrack(query):
+		applog.Infof("AUDIO", "Detected KHInsider URL")
+		directURL, _, err := resolveKHInsiderTrack(ctx, query, d.Format)
+		if err != nil {
+			return "", err
+		}
+		target = directURL
+		output := filepath.Join(dir, "shadowbox_download.%(ext)s")
+		return d.runDirectStrategies(ctx, target, output, dir)
 	case IsURL(query):
 		if IsBandcamp(query) {
 			applog.Infof("AUDIO", "Detected Bandcamp URL")
+		} else if IsKHInsider(query) {
+			applog.Infof("AUDIO", "Detected KHInsider URL")
 		} else {
 			applog.Infof("AUDIO", "Detected YouTube URL")
 		}
@@ -136,9 +206,17 @@ func (d *Downloader) Download(ctx context.Context, query, dir string) (string, e
 	return d.runStrategies(ctx, target, output, dir)
 }
 
+// runDirectStrategies attempts each direct-media strategy until one succeeds.
+func (d *Downloader) runDirectStrategies(ctx context.Context, target, output, dir string) (string, error) {
+	return d.runStrategySet(ctx, target, output, dir, d.directMediaStrategies())
+}
+
 // runStrategies attempts each strategy in order until one yields a valid file.
 func (d *Downloader) runStrategies(ctx context.Context, target, output, dir string) (string, error) {
-	strategies := d.strategies()
+	return d.runStrategySet(ctx, target, output, dir, d.strategies())
+}
+
+func (d *Downloader) runStrategySet(ctx context.Context, target, output, dir string, strategies []strategy) (string, error) {
 	for i, s := range strategies {
 		if i > 0 {
 			delay := time.Duration(2000+rand.Intn(3000)) * time.Millisecond

--- a/internal/download/khinsider.go
+++ b/internal/download/khinsider.go
@@ -1,0 +1,602 @@
+package download
+
+import (
+	"context"
+	"fmt"
+	htmlpkg "html"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/EnJulian/shadowbox/internal/organize"
+	"golang.org/x/net/html"
+)
+
+const khUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+// khScrapeDelay is the pause between successive KHInsider track page fetches.
+const khScrapeDelay = 500 * time.Millisecond
+
+var khTrackPageSuffix = map[string]bool{".mp3": true, ".flac": true}
+
+var (
+	khYearRe         = regexp.MustCompile(`(?i)Year:\s*<b>([^<]+)</b>`)
+	khNumFilesRe     = regexp.MustCompile(`(?i)Number of Files:\s*<b>(\d+)</b>`)
+	khSongNameRe     = regexp.MustCompile(`(?i)Song name:\s*<b>([^<]+)</b>`)
+	khDiscTrackRe    = regexp.MustCompile(`^(\d+)-(\d+)`)
+	khLeadingTrackRe = regexp.MustCompile(`^(\d+)[.\s_-]`)
+)
+
+const khMaxCoverBytes = 10 << 20 // 10 MiB
+
+// KHInsiderAlbumInfo holds album-level metadata scraped from a KHInsider page.
+type KHInsiderAlbumInfo struct {
+	AlbumURL    string
+	Title       string
+	Artist      string
+	AlbumArtist string
+	Composer    string
+	Composers   []string
+	Publisher   string
+	Platforms   string
+	Year        string
+	Genre       string
+	TotalTracks int
+	TotalDiscs  int
+	CoverURL    string
+	Tracks      []khTrack
+}
+
+// KHInsiderTrackInfo holds track-level metadata scraped from a KHInsider track page.
+type KHInsiderTrackInfo struct {
+	Title       string
+	TrackNumber string
+	DiscNumber  string
+}
+
+type khTrack struct {
+	Index   int
+	Title   string
+	PageURL string
+}
+
+type khClient struct {
+	HTTP *http.Client
+}
+
+func defaultKHClient() *khClient {
+	return &khClient{HTTP: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (c *khClient) fetch(ctx context.Context, pageURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", khUserAgent)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("KHInsider fetch failed: %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (c *khClient) fetchBytes(ctx context.Context, pageURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", khUserAgent)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("KHInsider fetch failed: %s", resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// KHInsiderAlbumURL returns the album page URL for a KHInsider album or track URL.
+func KHInsiderAlbumURL(rawURL string) string {
+	if IsKHInsiderPlaylist(rawURL) {
+		return rawURL
+	}
+	if !IsKHInsiderTrack(rawURL) {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	segs := khPathSegments(rawURL)
+	if len(segs) < 3 {
+		return ""
+	}
+	u.Path = "/" + strings.Join(segs[:3], "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+// FetchKHInsiderAlbumInfo scrapes album metadata and track list from a KHInsider album URL.
+func FetchKHInsiderAlbumInfo(ctx context.Context, albumURL string) (*KHInsiderAlbumInfo, error) {
+	return defaultKHClient().fetchAlbumInfo(ctx, albumURL)
+}
+
+func (c *khClient) fetchAlbumInfo(ctx context.Context, albumURL string) (*KHInsiderAlbumInfo, error) {
+	body, err := c.fetchBytes(ctx, albumURL)
+	if err != nil {
+		return nil, err
+	}
+	htmlBody := string(body)
+	doc, err := html.Parse(strings.NewReader(htmlBody))
+	if err != nil {
+		return nil, fmt.Errorf("parse album page: %w", err)
+	}
+
+	info := &KHInsiderAlbumInfo{
+		AlbumURL: albumURL,
+		CoverURL: findAlbumCoverURL(doc),
+	}
+	c.enrichAlbumFromInfoTxt(ctx, doc, info, albumURL)
+	applyHTMLAlbumFields(info, doc, htmlBody)
+	if m := khNumFilesRe.FindStringSubmatch(htmlBody); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			info.TotalTracks = n
+		}
+	}
+
+	base, err := url.Parse(albumURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid album URL: %w", err)
+	}
+	info.Tracks, err = c.parseAlbumTracks(doc, base)
+	if err != nil {
+		return nil, err
+	}
+	if info.TotalTracks == 0 {
+		info.TotalTracks = len(info.Tracks)
+	}
+	info.finalizeMetadata()
+	return info, nil
+}
+
+// FetchKHInsiderTrackInfo scrapes track title and disc/track numbers from a track page.
+func FetchKHInsiderTrackInfo(ctx context.Context, trackURL string) (*KHInsiderTrackInfo, error) {
+	return defaultKHClient().fetchTrackInfo(ctx, trackURL)
+}
+
+func (c *khClient) fetchTrackInfo(ctx context.Context, trackURL string) (*KHInsiderTrackInfo, error) {
+	body, err := c.fetchBytes(ctx, trackURL)
+	if err != nil {
+		return nil, err
+	}
+	htmlBody := string(body)
+	info := &KHInsiderTrackInfo{}
+	if m := khSongNameRe.FindStringSubmatch(htmlBody); len(m) == 2 {
+		info.Title = strings.TrimSpace(htmlUnescape(m[1]))
+	}
+	segs := khPathSegments(trackURL)
+	if len(segs) > 0 {
+		info.DiscNumber, info.TrackNumber = parseDiscTrackNumbers(segs[len(segs)-1])
+	}
+	if info.Title == "" && len(segs) > 0 {
+		info.Title = khTitleFromSegment(segs[len(segs)-1])
+	}
+	return info, nil
+}
+
+// KHInsiderTrackFromAlbum builds track metadata from scraped album data without
+// an extra HTTP request.
+func KHInsiderTrackFromAlbum(pageURL, title string, index int) *KHInsiderTrackInfo {
+	info := &KHInsiderTrackInfo{Title: title}
+	if index > 0 {
+		info.TrackNumber = strconv.Itoa(index)
+	}
+	segs := khPathSegments(pageURL)
+	if len(segs) > 0 {
+		disc, trackNum := parseDiscTrackNumbers(segs[len(segs)-1])
+		if disc != "" {
+			info.DiscNumber = disc
+		}
+		if trackNum != "" {
+			info.TrackNumber = trackNum
+		}
+	}
+	return info
+}
+
+// FetchKHCover downloads the album cover image bytes from a mirror URL.
+func FetchKHCover(ctx context.Context, coverURL string) ([]byte, string, error) {
+	return defaultKHClient().downloadCover(ctx, coverURL)
+}
+
+func (c *khClient) downloadCover(ctx context.Context, coverURL string) ([]byte, string, error) {
+	u, err := url.Parse(coverURL)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid cover URL: %w", err)
+	}
+	if strings.ToLower(u.Scheme) != "https" {
+		return nil, "", fmt.Errorf("cover URL must use HTTPS")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, coverURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("User-Agent", khUserAgent)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("cover download failed: %s", resp.Status)
+	}
+
+	mime := resp.Header.Get("Content-Type")
+	if mime == "" || !strings.HasPrefix(strings.ToLower(mime), "image/") {
+		return nil, "", fmt.Errorf("cover response is not an image")
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, khMaxCoverBytes+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) > khMaxCoverBytes {
+		return nil, "", fmt.Errorf("cover image exceeds size limit")
+	}
+	return data, mime, nil
+}
+
+func extractKHField(re *regexp.Regexp, htmlBody string) string {
+	if m := re.FindStringSubmatch(htmlBody); len(m) == 2 {
+		return strings.TrimSpace(htmlUnescape(m[1]))
+	}
+	return ""
+}
+
+func htmlUnescape(s string) string {
+	return htmlpkg.UnescapeString(s)
+}
+
+func firstH2Text(doc *html.Node) string {
+	var found string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "h2" {
+			found = strings.TrimSpace(textContent(n))
+			return
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+	return found
+}
+
+func findAlbumCoverURL(doc *html.Node) string {
+	var fullLinks []string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "div" && hasClass(n, "albumImage") {
+			for child := n.FirstChild; child != nil; child = child.NextSibling {
+				if child.Type == html.ElementNode && child.Data == "a" {
+					if href := attrVal(child, "href"); isKHCoverLink(href) {
+						fullLinks = append(fullLinks, href)
+					}
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+
+	prefer := []string{"front", "cover", "display", "box front"}
+	for _, key := range prefer {
+		for _, link := range fullLinks {
+			if strings.Contains(strings.ToLower(link), key) {
+				return link
+			}
+		}
+	}
+	if len(fullLinks) > 0 {
+		return fullLinks[0]
+	}
+	return ""
+}
+
+func isKHCoverLink(href string) bool {
+	if href == "" {
+		return false
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return false
+	}
+	if !strings.HasSuffix(strings.ToLower(u.Hostname()), "vgmtreasurechest.com") {
+		return false
+	}
+	if strings.Contains(strings.ToLower(u.Path), "/thumbs/") {
+		return false
+	}
+	ext := strings.ToLower(path.Ext(u.Path))
+	return ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".webp"
+}
+
+func hasClass(n *html.Node, want string) bool {
+	for _, a := range n.Attr {
+		if a.Key == "class" && a.Val == want {
+			return true
+		}
+	}
+	return false
+}
+
+func parseDiscTrackNumbers(segment string) (disc, track string) {
+	decoded, err := url.PathUnescape(segment)
+	if err != nil {
+		decoded = segment
+	}
+	decoded = strings.TrimSuffix(decoded, path.Ext(decoded))
+	if m := khDiscTrackRe.FindStringSubmatch(decoded); len(m) == 3 {
+		return m[1], m[2]
+	}
+	if m := khLeadingTrackRe.FindStringSubmatch(decoded); len(m) == 2 {
+		return "1", m[1]
+	}
+	return "", ""
+}
+
+func (c *khClient) parseAlbumTracks(doc *html.Node, base *url.URL) ([]khTrack, error) {
+	seen := make(map[string]bool)
+	var tracks []khTrack
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := attrVal(n, "href")
+			if href != "" {
+				if track, ok := parseKHTrackLink(href, n, base); ok && !seen[track.PageURL] {
+					seen[track.PageURL] = true
+					track.Index = len(tracks) + 1
+					segs := khPathSegments(track.PageURL)
+					if len(segs) > 0 {
+						_, trackNum := parseDiscTrackNumbers(segs[len(segs)-1])
+						if trackNum != "" {
+							track.Title = strings.TrimSpace(strings.TrimPrefix(track.Title, trackNum+". "))
+							track.Title = strings.TrimSpace(strings.TrimPrefix(track.Title, trackNum+" - "))
+						}
+					}
+					tracks = append(tracks, track)
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+	return tracks, nil
+}
+
+func scrapeKHInsiderAlbum(ctx context.Context, albumURL string) ([]khTrack, error) {
+	info, err := defaultKHClient().fetchAlbumInfo(ctx, albumURL)
+	if err != nil {
+		return nil, err
+	}
+	if len(info.Tracks) == 0 {
+		return nil, fmt.Errorf("no tracks found on KHInsider album page")
+	}
+	return info.Tracks, nil
+}
+
+func parseKHTrackLink(href string, n *html.Node, base *url.URL) (khTrack, bool) {
+	ref, err := url.Parse(href)
+	if err != nil {
+		return khTrack{}, false
+	}
+	abs := base.ResolveReference(ref)
+	segs := khPathSegments(abs.String())
+	if len(segs) <= 3 || segs[0] != "game-soundtracks" || segs[1] != "album" {
+		return khTrack{}, false
+	}
+	ext := strings.ToLower(path.Ext(segs[len(segs)-1]))
+	if !khTrackPageSuffix[ext] {
+		return khTrack{}, false
+	}
+	title := strings.TrimSpace(textContent(n))
+	if title == "" {
+		title = khTitleFromSegment(segs[len(segs)-1])
+	}
+	return khTrack{
+		Title:   title,
+		PageURL: abs.String(),
+	}, true
+}
+
+func resolveKHInsiderTrack(ctx context.Context, trackURL, preferredFormat string) (directURL, title string, err error) {
+	return defaultKHClient().resolveTrack(ctx, trackURL, preferredFormat)
+}
+
+func (c *khClient) resolveTrack(ctx context.Context, trackURL, preferredFormat string) (directURL, title string, err error) {
+	htmlBody, err := c.fetch(ctx, trackURL)
+	if err != nil {
+		return "", "", err
+	}
+	doc, err := html.Parse(strings.NewReader(htmlBody))
+	if err != nil {
+		return "", "", fmt.Errorf("parse track page: %w", err)
+	}
+
+	audioSrc := findAudioSrc(doc)
+	flacLink, mp3Link := findMirrorLinks(doc)
+
+	directURL = pickDirectURL(preferredFormat, audioSrc, flacLink, mp3Link)
+	if directURL == "" {
+		return "", "", fmt.Errorf("no direct download link found on KHInsider track page")
+	}
+
+	if m := khSongNameRe.FindStringSubmatch(htmlBody); len(m) == 2 {
+		title = strings.TrimSpace(htmlUnescape(m[1]))
+	}
+	if title == "" {
+		segs := khPathSegments(trackURL)
+		if len(segs) > 0 {
+			title = khTitleFromSegment(segs[len(segs)-1])
+		} else {
+			title = "Unknown Track"
+		}
+	}
+	return directURL, title, nil
+}
+
+func pickDirectURL(preferredFormat, audioSrc, flacLink, mp3Link string) string {
+	wantFlac := strings.EqualFold(preferredFormat, "flac")
+	if wantFlac {
+		if flacLink != "" {
+			return flacLink
+		}
+		if audioSrc != "" && strings.HasSuffix(strings.ToLower(audioSrc), ".flac") {
+			return audioSrc
+		}
+		if mp3Link != "" {
+			return mp3Link
+		}
+		return audioSrc
+	}
+	if mp3Link != "" {
+		return mp3Link
+	}
+	if audioSrc != "" && strings.HasSuffix(strings.ToLower(audioSrc), ".mp3") {
+		return audioSrc
+	}
+	if flacLink != "" {
+		return flacLink
+	}
+	return audioSrc
+}
+
+func findAudioSrc(doc *html.Node) string {
+	var found string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "audio" {
+			if id := attrVal(n, "id"); id == "audio" || found == "" {
+				if src := attrVal(n, "src"); src != "" {
+					found = src
+					if id == "audio" {
+						return
+					}
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+	return found
+}
+
+func findMirrorLinks(doc *html.Node) (flac, mp3 string) {
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := attrVal(n, "href")
+			if isMirrorMediaLink(href) {
+				lower := strings.ToLower(href)
+				if strings.HasSuffix(lower, ".flac") && flac == "" {
+					flac = href
+				}
+				if strings.HasSuffix(lower, ".mp3") && mp3 == "" {
+					mp3 = href
+				}
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+	return flac, mp3
+}
+
+func isMirrorMediaLink(href string) bool {
+	if href == "" {
+		return false
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if !strings.HasSuffix(host, "vgmtreasurechest.com") {
+		return false
+	}
+	ext := strings.ToLower(path.Ext(u.Path))
+	return ext == ".mp3" || ext == ".flac"
+}
+
+func khTitleFromSegment(segment string) string {
+	decoded, err := url.PathUnescape(segment)
+	if err != nil {
+		decoded = segment
+	}
+	ext := path.Ext(decoded)
+	title := strings.TrimSuffix(decoded, ext)
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return "Unknown Track"
+	}
+	return title
+}
+
+func sanitizeKHOutputTitle(title string) string {
+	return organize.SanitizeFilename(title)
+}
+
+func attrVal(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func textContent(n *html.Node) string {
+	if n == nil {
+		return ""
+	}
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var sb strings.Builder
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		sb.WriteString(textContent(child))
+	}
+	return sb.String()
+}

--- a/internal/download/khinsider.go
+++ b/internal/download/khinsider.go
@@ -274,25 +274,6 @@ func htmlUnescape(s string) string {
 	return htmlpkg.UnescapeString(s)
 }
 
-func firstH2Text(doc *html.Node) string {
-	var found string
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
-		if found != "" {
-			return
-		}
-		if n.Type == html.ElementNode && n.Data == "h2" {
-			found = strings.TrimSpace(textContent(n))
-			return
-		}
-		for child := n.FirstChild; child != nil; child = child.NextSibling {
-			walk(child)
-		}
-	}
-	walk(doc)
-	return found
-}
-
 func findAlbumCoverURL(doc *html.Node) string {
 	var fullLinks []string
 	var walk func(*html.Node)

--- a/internal/download/khinsider_metadata.go
+++ b/internal/download/khinsider_metadata.go
@@ -1,0 +1,259 @@
+package download
+
+import (
+	"context"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"golang.org/x/net/html"
+)
+
+var (
+	khPublishedRe = regexp.MustCompile(`(?is)Published by:\s*(?:<a[^>]*>([^<]+)</a>|<b>([^<]+)</b>|([^<\n]+))`)
+	khAlbumTypeRe = regexp.MustCompile(`(?is)Album type:\s*<b>(?:\s*<a[^>]*>([^<]+)</a>|([^<]+?))\s*</b>`)
+	khPlatformsRe = regexp.MustCompile(`(?is)Platforms:\s*(?:<a[^>]*>([^<]+)</a>|([^<,\n]+))`)
+	khComposerLineRe = regexp.MustCompile(`(?is)Composer:\s*([^<\n]+)`)
+)
+
+func extractKHFieldGroups(re *regexp.Regexp, htmlBody string) string {
+	m := re.FindStringSubmatch(htmlBody)
+	if m == nil {
+		return ""
+	}
+	for i := 1; i < len(m); i++ {
+		if s := strings.TrimSpace(htmlUnescape(m[i])); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func findInfoTxtURL(doc *html.Node) string {
+	var found string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "a" {
+			if href := attrVal(n, "href"); strings.Contains(strings.ToLower(href), "khinsider.info.txt") {
+				found = href
+				return
+			}
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(doc)
+	return found
+}
+
+func parseInfoTxt(body string) (title, year, publisher, platforms string, composers []string) {
+	lines := strings.Split(body, "\n")
+	inMusicBy := false
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "Name:"):
+			title = strings.TrimSpace(strings.TrimPrefix(line, "Name:"))
+		case strings.HasPrefix(line, "Year:"):
+			year = strings.TrimSpace(strings.TrimPrefix(line, "Year:"))
+		case strings.HasPrefix(line, "Published by:"):
+			publisher = strings.TrimSpace(strings.TrimPrefix(line, "Published by:"))
+		case strings.HasPrefix(line, "Platforms:"):
+			platforms = strings.TrimSpace(strings.TrimPrefix(line, "Platforms:"))
+		case line == "Music by":
+			inMusicBy = true
+		case strings.HasPrefix(line, "Disc "):
+			inMusicBy = false
+		case strings.HasPrefix(line, "Description:"):
+			inMusicBy = false
+		case inMusicBy:
+			if name := composerNameFromCredit(line); name != "" {
+				composers = appendUnique(composers, name)
+			}
+		}
+	}
+	return title, year, publisher, platforms, composers
+}
+
+func composerNameFromCredit(line string) string {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ""
+	}
+	if i := strings.Index(line, "("); i > 0 {
+		line = strings.TrimSpace(line[:i])
+	}
+	line = strings.TrimLeftFunc(line, unicode.IsSpace)
+	if line == "" || strings.HasPrefix(strings.ToLower(line), "vocals:") {
+		return ""
+	}
+	return line
+}
+
+func appendUnique(list []string, val string) []string {
+	for _, existing := range list {
+		if strings.EqualFold(existing, val) {
+			return list
+		}
+	}
+	return append(list, val)
+}
+
+func artistFromComposers(composers []string) string {
+	switch len(composers) {
+	case 0:
+		return ""
+	case 1:
+		return composers[0]
+	default:
+		return "Various Artists"
+	}
+}
+
+func mergeInfoTxtFields(info *KHInsiderAlbumInfo, title, year, publisher, platforms string, composers []string) {
+	if title != "" {
+		info.Title = title
+	}
+	if year != "" {
+		info.Year = year
+	}
+	if publisher != "" {
+		info.Publisher = publisher
+	}
+	if platforms != "" {
+		info.Platforms = platforms
+	}
+	if len(composers) > 0 {
+		info.Composers = composers
+		info.Artist = artistFromComposers(composers)
+	}
+}
+
+func applyHTMLAlbumFields(info *KHInsiderAlbumInfo, doc *html.Node, htmlBody string) {
+	if info.Title == "" {
+		info.Title = strings.TrimSpace(htmlUnescape(firstAlbumTitle(doc)))
+	}
+	if info.Year == "" {
+		info.Year = extractKHField(khYearRe, htmlBody)
+	}
+	if info.Publisher == "" {
+		info.Publisher = extractKHFieldGroups(khPublishedRe, htmlBody)
+	}
+	if info.Genre == "" {
+		info.Genre = extractKHFieldGroups(khAlbumTypeRe, htmlBody)
+	}
+	if info.Platforms == "" {
+		info.Platforms = extractKHFieldGroups(khPlatformsRe, htmlBody)
+	}
+	if info.Composer == "" {
+		if c := extractKHFieldGroups(khComposerLineRe, htmlBody); c != "" {
+			info.Composer = c
+			if name := composerNameFromCredit(c); name != "" && info.Artist == "" {
+				info.Artist = name
+			}
+		}
+	}
+}
+
+func firstAlbumTitle(doc *html.Node) string {
+	var found string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "h2" {
+			title := strings.TrimSpace(textContent(n))
+			lower := strings.ToLower(title)
+			if lower == "description" || lower == "comments" || lower == "ooops!" {
+				return
+			}
+			found = title
+			return
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+		 walk(child)
+		}
+	}
+	walk(doc)
+	return found
+}
+
+func (info *KHInsiderAlbumInfo) finalizeMetadata() {
+	if info.Genre == "" && info.Platforms != "" {
+		info.Genre = "Video Game"
+	}
+	if info.Artist == "" && info.Composer != "" {
+		if name := composerNameFromCredit(info.Composer); name != "" {
+			info.Artist = name
+		}
+	}
+	if info.Artist == "" && len(info.Composers) > 0 {
+		info.Artist = artistFromComposers(info.Composers)
+	}
+	if info.Artist == "" && info.Publisher != "" {
+		info.Artist = info.Publisher
+	}
+	if info.AlbumArtist == "" {
+		info.AlbumArtist = info.Publisher
+	}
+	if info.AlbumArtist == "" {
+		info.AlbumArtist = info.Artist
+	}
+	if info.TotalDiscs == 0 {
+		info.TotalDiscs = maxDiscFromTracks(info.Tracks)
+	}
+}
+
+func maxDiscFromTracks(tracks []khTrack) int {
+	maxDisc := 0
+	for _, t := range tracks {
+		segs := khPathSegments(t.PageURL)
+		if len(segs) == 0 {
+			continue
+		}
+		disc, _ := parseDiscTrackNumbers(segs[len(segs)-1])
+		if disc == "" {
+			continue
+		}
+		if n := atoiSafe(disc); n > maxDisc {
+			maxDisc = n
+		}
+	}
+	return maxDisc
+}
+
+func atoiSafe(s string) int {
+	n, _ := strconv.Atoi(strings.TrimSpace(s))
+	return n
+}
+
+func (c *khClient) enrichAlbumFromInfoTxt(ctx context.Context, doc *html.Node, info *KHInsiderAlbumInfo, albumURL string) {
+	href := findInfoTxtURL(doc)
+	if href == "" {
+		return
+	}
+	base, err := url.Parse(albumURL)
+	if err != nil {
+		return
+	}
+	ref, err := url.Parse(href)
+	if err != nil {
+		return
+	}
+	body, err := c.fetchBytes(ctx, base.ResolveReference(ref).String())
+	if err != nil {
+		return
+	}
+	title, year, publisher, platforms, composers := parseInfoTxt(string(body))
+	mergeInfoTxtFields(info, title, year, publisher, platforms, composers)
+}

--- a/internal/download/khinsider_test.go
+++ b/internal/download/khinsider_test.go
@@ -1,0 +1,230 @@
+package download
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const albumHTMLFixture = `<!DOCTYPE html><html><body>
+<h2>Test Game Soundtrack</h2>
+<p>Year: <b>2024</b><br>
+Published by: <a href="/publisher/test">Test Publisher</a><br>
+Album type: <b><a href="/game-soundtracks/ost">Soundtrack</a></b><br>
+Number of Files: <b>3</b></p>
+<div class="albumImage">
+<a href="https://nu.vgmtreasurechest.com/soundtracks/test/00%20Front.jpg">
+<img src="https://nu.vgmtreasurechest.com/soundtracks/test/thumbs/00%20Front.jpg">
+</a></div>
+<table>
+<tr><td><a href="/game-soundtracks/album/test-album/01.%20Opening.mp3">01. Opening</a></td></tr>
+<tr><td><a href="/game-soundtracks/album/test-album/02.%20Battle.mp3">02. Battle</a></td></tr>
+<tr><td><a href="/game-soundtracks/album/test-album/01.%20Opening.mp3">duplicate</a></td></tr>
+<tr><td><a href="/game-soundtracks/album/test-album/03.%20Ending.flac">03. Ending</a></td></tr>
+<tr><td><a href="/other/page">skip</a></td></tr>
+</table>
+</body></html>`
+
+const trackHTMLFixture = `<!DOCTYPE html><html><body>
+<p>Song name: <b>Opening Theme</b></p>
+<audio id="audio" src="https://nu.vgmtreasurechest.com/soundtracks/test/01-opening.mp3"></audio>
+<a href="https://nu.vgmtreasurechest.com/soundtracks/test/01-opening.flac">Download FLAC</a>
+<a href="https://nu.vgmtreasurechest.com/soundtracks/test/01-opening.mp3">Download MP3</a>
+</body></html>`
+
+func TestScrapeKHInsiderAlbum(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, albumHTMLFixture)
+	}))
+	defer srv.Close()
+
+	tracks, err := scrapeKHInsiderAlbum(context.Background(), srv.URL+"/game-soundtracks/album/test-album")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tracks) != 3 {
+		t.Fatalf("got %d tracks, want 3", len(tracks))
+	}
+	if tracks[0].Index != 1 || tracks[0].Title != "Opening" {
+		t.Errorf("track 1 = %+v", tracks[0])
+	}
+	if tracks[1].Title != "Battle" {
+		t.Errorf("track 2 title = %q", tracks[1].Title)
+	}
+	if !strings.HasSuffix(tracks[2].PageURL, "03.%20Ending.flac") {
+		t.Errorf("track 3 url = %q", tracks[2].PageURL)
+	}
+}
+
+func TestResolveKHInsiderTrackPreferredFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, trackHTMLFixture)
+	}))
+	defer srv.Close()
+
+	c := &khClient{HTTP: srv.Client()}
+	trackURL := srv.URL + "/game-soundtracks/album/test-album/01.%20Opening.mp3"
+
+	direct, title, err := c.resolveTrack(context.Background(), trackURL, "opus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if direct != "https://nu.vgmtreasurechest.com/soundtracks/test/01-opening.mp3" {
+		t.Errorf("opus preferred direct = %q", direct)
+	}
+	if title != "Opening Theme" {
+		t.Errorf("title = %q", title)
+	}
+
+	direct, title, err = c.resolveTrack(context.Background(), trackURL, "flac")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if direct != "https://nu.vgmtreasurechest.com/soundtracks/test/01-opening.flac" {
+		t.Errorf("flac preferred direct = %q", direct)
+	}
+	if title != "Opening Theme" {
+		t.Errorf("flac resolve title = %q", title)
+	}
+}
+
+func TestFetchKHInsiderAlbumInfo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, albumHTMLFixture)
+	}))
+	defer srv.Close()
+
+	c := &khClient{HTTP: srv.Client()}
+	info, err := c.fetchAlbumInfo(context.Background(), srv.URL+"/game-soundtracks/album/test-album")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Title != "Test Game Soundtrack" {
+		t.Errorf("title = %q", info.Title)
+	}
+	if info.Artist != "Test Publisher" {
+		t.Errorf("artist = %q, want Test Publisher", info.Artist)
+	}
+	if info.AlbumArtist != "Test Publisher" {
+		t.Errorf("album artist = %q, want Test Publisher", info.AlbumArtist)
+	}
+	if info.Year != "2024" || info.Genre != "Soundtrack" || info.TotalTracks != 3 {
+		t.Errorf("metadata = %+v", info)
+	}
+	if !strings.Contains(info.CoverURL, "00%20Front.jpg") {
+		t.Errorf("cover = %q", info.CoverURL)
+	}
+}
+
+func TestFetchKHInsiderTrackInfo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, trackHTMLFixture)
+	}))
+	defer srv.Close()
+
+	c := &khClient{HTTP: srv.Client()}
+	info, err := c.fetchTrackInfo(context.Background(), srv.URL+"/game-soundtracks/album/test-album/1-02.%20Battle.mp3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Title != "Opening Theme" {
+		t.Errorf("title = %q", info.Title)
+	}
+	if info.DiscNumber != "1" || info.TrackNumber != "02" {
+		t.Errorf("disc/track = %q/%q", info.DiscNumber, info.TrackNumber)
+	}
+}
+
+func TestKHInsiderAlbumURL(t *testing.T) {
+	track := "https://downloads.khinsider.com/game-soundtracks/album/foo/01.%20Bar.mp3"
+	want := "https://downloads.khinsider.com/game-soundtracks/album/foo"
+	if got := KHInsiderAlbumURL(track); got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestPickDirectURL(t *testing.T) {
+	audio := "https://nu.vgmtreasurechest.com/a.flac"
+	flac := "https://nu.vgmtreasurechest.com/b.flac"
+	mp3 := "https://nu.vgmtreasurechest.com/c.mp3"
+
+	if got := pickDirectURL("flac", audio, flac, mp3); got != flac {
+		t.Errorf("flac preference = %q", got)
+	}
+	if got := pickDirectURL("opus", audio, flac, mp3); got != mp3 {
+		t.Errorf("opus preference = %q", got)
+	}
+}
+
+func TestKHTitleFromSegment(t *testing.T) {
+	if got := khTitleFromSegment("01.%20Opening.mp3"); got != "01. Opening" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSanitizeKHOutputTitle(t *testing.T) {
+	if got := sanitizeKHOutputTitle(`Track: "Boss"/Fight`); got != `Track_ _Boss__Fight` {
+		t.Errorf("got %q", got)
+	}
+}
+
+const infoTxtFixture = `Name: Kirby Star Allies
+Year: 2018
+Platforms: Switch
+Published by: HAL Laboratory
+
+Music by
+Tadashi Ikegami (HAL Laboratory)
+Hirokazu Ando (HAL Laboratory)
+
+Disc 1
+1-01. Kirby Star Allies Main Theme
+`
+
+func TestParseInfoTxt(t *testing.T) {
+	title, year, publisher, platforms, composers := parseInfoTxt(infoTxtFixture)
+	if title != "Kirby Star Allies" {
+		t.Errorf("title = %q", title)
+	}
+	if year != "2018" || publisher != "HAL Laboratory" || platforms != "Switch" {
+		t.Errorf("fields = %q %q %q", year, publisher, platforms)
+	}
+	if len(composers) != 2 {
+		t.Fatalf("composers = %v", composers)
+	}
+	if got := artistFromComposers(composers); got != "Various Artists" {
+		t.Errorf("artist = %q", got)
+	}
+}
+
+func TestFetchKHInsiderAlbumInfoFromInfoTxt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "khinsider.info.txt") {
+			fmt.Fprint(w, infoTxtFixture)
+			return
+		}
+		body := strings.Replace(albumHTMLFixture,
+			`</body></html>`,
+			`<a href="/game-soundtracks/album/test-album/khinsider.info.txt">info</a></body></html>`, 1)
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := &khClient{HTTP: srv.Client()}
+	info, err := c.fetchAlbumInfo(context.Background(), srv.URL+"/game-soundtracks/album/test-album")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Artist != "Various Artists" {
+		t.Errorf("artist = %q, want Various Artists", info.Artist)
+	}
+	if info.AlbumArtist != "HAL Laboratory" {
+		t.Errorf("album artist = %q, want HAL Laboratory", info.AlbumArtist)
+	}
+	if info.Title != "Kirby Star Allies" {
+		t.Errorf("title = %q", info.Title)
+	}
+}

--- a/internal/download/playlist.go
+++ b/internal/download/playlist.go
@@ -1,16 +1,23 @@
 package download
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	applog "github.com/EnJulian/shadowbox/internal/log"
+	"github.com/EnJulian/shadowbox/internal/progress"
 )
 
 // DownloadPlaylist downloads every track of a YouTube playlist into dir and
@@ -24,6 +31,10 @@ func (d *Downloader) DownloadPlaylist(ctx context.Context, url, dir string) ([]s
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
+	}
+
+	if IsKHInsider(url) {
+		return d.downloadKHInsiderAlbum(ctx, url, dir)
 	}
 
 	output := filepath.Join(dir, "%(playlist_index)s - %(title)s.%(ext)s")
@@ -43,8 +54,37 @@ func (d *Downloader) DownloadPlaylist(ctx context.Context, url, dir string) ([]s
 	applog.Systemf("GET", "yt-dlp %s", strings.Join(args, " "))
 
 	cmd := exec.CommandContext(ctx, "yt-dlp", args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("playlist download failed: %s", truncate(string(out), 200))
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	var logBuf bytes.Buffer
+	var logMu sync.Mutex
+	safeLog := &lockedWriter{mu: &logMu, w: &logBuf}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	done := make(chan struct{}, 2)
+	tee := func(r io.Reader) io.Reader {
+		return io.TeeReader(r, safeLog)
+	}
+	go func() {
+		d.scanYTDLPProgress(tee(stdout))
+		done <- struct{}{}
+	}()
+	go func() {
+		d.scanYTDLPProgress(tee(stderr))
+		done <- struct{}{}
+	}()
+	cmdErr := cmd.Wait()
+	<-done
+	<-done
+	if cmdErr != nil {
+		return nil, fmt.Errorf("playlist download failed: %s", truncate(logBuf.String(), 200))
 	}
 
 	files := matchingFiles(dir, d.Format)
@@ -53,6 +93,48 @@ func (d *Downloader) DownloadPlaylist(ctx context.Context, url, dir string) ([]s
 	}
 	sortByPlaylistIndex(files)
 	applog.Successf("DOWNLOAD", "Downloaded %d tracks from playlist", len(files))
+	return files, nil
+}
+
+func (d *Downloader) downloadKHInsiderAlbum(ctx context.Context, albumURL, dir string) ([]string, error) {
+	applog.Infof("PLAYLIST", "Detected KHInsider album")
+	tracks, err := scrapeKHInsiderAlbum(ctx, albumURL)
+	if err != nil {
+		return nil, err
+	}
+	applog.Infof("PLAYLIST", "Found %d tracks", len(tracks))
+
+	for i, track := range tracks {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(khScrapeDelay):
+			}
+		}
+
+		directURL, title, err := resolveKHInsiderTrack(ctx, track.PageURL, d.Format)
+		if err != nil {
+			return nil, fmt.Errorf("track %d (%s): %w", track.Index, track.Title, err)
+		}
+		if title == "" {
+			title = track.Title
+		}
+		safeTitle := sanitizeKHOutputTitle(title)
+		output := filepath.Join(dir, fmt.Sprintf("%02d - %s.%%(ext)s", track.Index, safeTitle))
+		applog.Infof("PLAYLIST", "Downloading track %d/%d: %s", track.Index, len(tracks), safeTitle)
+		d.reportProgress("downloading track", track.Index, len(tracks))
+		if _, err := d.runDirectStrategies(ctx, directURL, output, dir); err != nil {
+			return nil, fmt.Errorf("track %d (%s): %w", track.Index, safeTitle, err)
+		}
+	}
+
+	files := matchingFiles(dir, d.Format)
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no %s files found after KHInsider album download", d.Format)
+	}
+	sortByPlaylistIndex(files)
+	applog.Successf("DOWNLOAD", "Downloaded %d tracks from KHInsider album", len(files))
 	return files, nil
 }
 
@@ -132,4 +214,37 @@ func sortByPlaylistIndex(files []string) {
 	sort.SliceStable(files, func(i, j int) bool {
 		return indexOf(files[i]) < indexOf(files[j])
 	})
+}
+
+var ytDLPItemProgress = regexp.MustCompile(`(?i)(?:item|video)\s+(\d+)\s+of\s+(\d+)`)
+
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}
+
+func (d *Downloader) reportProgress(stage string, current, total int) {
+	if d.Progress != nil {
+		d.Progress(progress.Update{Stage: stage, Current: current, Total: total})
+	}
+}
+
+func (d *Downloader) scanYTDLPProgress(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if m := ytDLPItemProgress.FindStringSubmatch(line); len(m) == 3 {
+			current, _ := strconv.Atoi(m[1])
+			total, _ := strconv.Atoi(m[2])
+			if current > 0 && total > 0 {
+				d.reportProgress("downloading track", current, total)
+			}
+		}
+	}
 }

--- a/internal/download/playlist_progress_test.go
+++ b/internal/download/playlist_progress_test.go
@@ -1,0 +1,33 @@
+package download
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/EnJulian/shadowbox/internal/progress"
+)
+
+func TestScanYTDLPProgress(t *testing.T) {
+	var got []progress.Update
+	d := &Downloader{
+		Progress: func(u progress.Update) {
+			got = append(got, u)
+		},
+	}
+	input := strings.NewReader(
+		"[download] Downloading item 2 of 5\n" +
+			"[download] 100% of 3.45MiB\n" +
+			"[download] Downloading video 3 of 5\n",
+	)
+	d.scanYTDLPProgress(input)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 updates, got %d: %+v", len(got), got)
+	}
+	if got[0].Current != 2 || got[0].Total != 5 || got[0].Stage != "downloading track" {
+		t.Fatalf("unexpected first update: %+v", got[0])
+	}
+	if got[1].Current != 3 || got[1].Total != 5 {
+		t.Fatalf("unexpected second update: %+v", got[1])
+	}
+}

--- a/internal/download/url.go
+++ b/internal/download/url.go
@@ -38,6 +38,49 @@ func IsYouTubePlaylist(rawURL string) bool {
 	return IsYouTube(rawURL) && (strings.Contains(u, "playlist") || strings.Contains(u, "list="))
 }
 
+// IsKHInsider reports whether the URL points to KHInsider.
+func IsKHInsider(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "khinsider.com" ||
+		host == "www.khinsider.com" ||
+		host == "downloads.khinsider.com"
+}
+
+// IsKHInsiderPlaylist reports whether the URL is a KHInsider album page.
+func IsKHInsiderPlaylist(rawURL string) bool {
+	if !IsKHInsider(rawURL) {
+		return false
+	}
+	segs := khPathSegments(rawURL)
+	return len(segs) == 3 &&
+		segs[0] == "game-soundtracks" &&
+		segs[1] == "album"
+}
+
+// IsKHInsiderTrack reports whether the URL is a KHInsider track page.
+func IsKHInsiderTrack(rawURL string) bool {
+	if !IsKHInsider(rawURL) {
+		return false
+	}
+	return len(khPathSegments(rawURL)) > 3
+}
+
+func khPathSegments(rawURL string) []string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil
+	}
+	path := strings.Trim(u.Path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
 // ValidateInput checks query/URL inputs before passing them to yt-dlp.
 func ValidateInput(input string) error {
 	input = strings.TrimSpace(input)
@@ -90,6 +133,11 @@ func isAllowedHost(host string) bool {
 		return true
 	}
 	if host == "bandcamp.com" || strings.HasSuffix(host, ".bandcamp.com") {
+		return true
+	}
+	if host == "khinsider.com" ||
+		host == "www.khinsider.com" ||
+		host == "downloads.khinsider.com" {
 		return true
 	}
 	return false

--- a/internal/download/url_test.go
+++ b/internal/download/url_test.go
@@ -8,19 +8,31 @@ import (
 
 func TestURLClassifiers(t *testing.T) {
 	cases := []struct {
-		url        string
-		isURL      bool
-		isYT       bool
-		isPlaylist bool
-		isBandcamp bool
+		url             string
+		isURL           bool
+		isYT            bool
+		isPlaylist      bool
+		isBandcamp      bool
+		isKHInsider     bool
+		isKHPlaylist    bool
+		isKHTrack       bool
 	}{
-		{"https://www.youtube.com/watch?v=dQw4w9WgXcQ", true, true, false, false},
-		{"https://youtu.be/dQw4w9WgXcQ", true, true, false, false},
-		{"https://www.youtube.com/playlist?list=PL123", true, true, true, false},
-		{"https://music.youtube.com/watch?v=x&list=RDABC", true, true, true, false},
-		{"https://artist.bandcamp.com/album/foo", true, false, false, true},
-		{"Imagine Dragons Believer", false, false, false, false},
-		{"  https://youtu.be/abc  ", true, true, false, false},
+		{"https://www.youtube.com/watch?v=dQw4w9WgXcQ", true, true, false, false, false, false, false},
+		{"https://youtu.be/dQw4w9WgXcQ", true, true, false, false, false, false, false},
+		{"https://www.youtube.com/playlist?list=PL123", true, true, true, false, false, false, false},
+		{"https://music.youtube.com/watch?v=x&list=RDABC", true, true, true, false, false, false, false},
+		{"https://artist.bandcamp.com/album/foo", true, false, false, true, false, false, false},
+		{"Imagine Dragons Believer", false, false, false, false, false, false, false},
+		{"  https://youtu.be/abc  ", true, true, false, false, false, false, false},
+		{
+			"https://downloads.khinsider.com/game-soundtracks/album/kirby-and-the-forgotten-land-the-complete-soundtrack-2024",
+			true, false, false, false, true, true, false,
+		},
+		{
+			"https://downloads.khinsider.com/game-soundtracks/album/kirby-and-the-forgotten-land-the-complete-soundtrack-2024/01.%20Welcome.mp3",
+			true, false, false, false, true, false, true,
+		},
+		{"https://www.khinsider.com/game-soundtracks/album/test-album", true, false, false, false, true, true, false},
 	}
 	for _, c := range cases {
 		if got := IsURL(c.url); got != c.isURL {
@@ -34,6 +46,15 @@ func TestURLClassifiers(t *testing.T) {
 		}
 		if got := IsBandcamp(c.url); got != c.isBandcamp {
 			t.Errorf("IsBandcamp(%q) = %v, want %v", c.url, got, c.isBandcamp)
+		}
+		if got := IsKHInsider(c.url); got != c.isKHInsider {
+			t.Errorf("IsKHInsider(%q) = %v, want %v", c.url, got, c.isKHInsider)
+		}
+		if got := IsKHInsiderPlaylist(c.url); got != c.isKHPlaylist {
+			t.Errorf("IsKHInsiderPlaylist(%q) = %v, want %v", c.url, got, c.isKHPlaylist)
+		}
+		if got := IsKHInsiderTrack(c.url); got != c.isKHTrack {
+			t.Errorf("IsKHInsiderTrack(%q) = %v, want %v", c.url, got, c.isKHTrack)
 		}
 	}
 }
@@ -63,6 +84,8 @@ func TestValidateInput(t *testing.T) {
 		{"https://www.youtube.com/watch?v=dQw4w9WgXcQ", true},
 		{"https://artist.bandcamp.com/album/foo", true},
 		{"http://www.youtube.com/watch?v=dQw4w9WgXcQ", true},
+		{"https://downloads.khinsider.com/game-soundtracks/album/test-album", true},
+		{"https://downloads.khinsider.com/game-soundtracks/album/test-album/01.%20Track.mp3", true},
 		{"https://evil.example/video", false},
 		{"ftp://www.youtube.com/watch?v=x", false},
 		{"", false},
@@ -96,6 +119,17 @@ func TestStrategyArgsUseOptionTerminator(t *testing.T) {
 		}
 		if strings.Contains(strings.Join(args[:len(args)-2], " "), target) {
 			t.Errorf("strategy %q embeds target before terminator", s.name)
+		}
+	}
+}
+
+func TestDirectStrategyArgsUseOptionTerminator(t *testing.T) {
+	d := New("opus")
+	target := "https://nu.vgmtreasurechest.com/soundtracks/example/track.mp3"
+	for _, s := range d.directMediaStrategies() {
+		args := appendTarget(s.args(d.Format, "out.%(ext)s"), target)
+		if len(args) < 2 || args[len(args)-2] != "--" || args[len(args)-1] != target {
+			t.Errorf("strategy %q args missing -- terminator: %v", s.name, args)
 		}
 	}
 }

--- a/internal/log/capture.go
+++ b/internal/log/capture.go
@@ -1,0 +1,149 @@
+package log
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultMaxDownloadLogLines = 2000
+
+// DownloadLog captures download pipeline output for the interactive console.
+type DownloadLog struct {
+	mu       sync.Mutex
+	lines    []string
+	maxLines int
+	filePath string
+}
+
+var downloadLog = &DownloadLog{maxLines: defaultMaxDownloadLogLines}
+
+// DownloadLogWriter returns a writer that records log output for the download log
+// viewer and on-disk history.
+func DownloadLogWriter() *DownloadLog { return downloadLog }
+
+// Write implements io.Writer.
+func (d *DownloadLog) Write(p []byte) (int, error) {
+	text := string(p)
+	if text == "" {
+		return 0, nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		d.appendLocked(line)
+	}
+	return len(p), nil
+}
+
+func (d *DownloadLog) appendLocked(line string) {
+	d.lines = append(d.lines, line)
+	if len(d.lines) > d.maxLines {
+		d.lines = d.lines[len(d.lines)-d.maxLines:]
+	}
+	d.appendFileLocked(line)
+}
+
+func (d *DownloadLog) appendFileLocked(line string) {
+	path, err := d.resolveFilePathLocked()
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintln(f, line)
+	_ = f.Close()
+}
+
+func (d *DownloadLog) resolveFilePathLocked() (string, error) {
+	if d.filePath != "" {
+		return d.filePath, nil
+	}
+	path, err := DownloadLogPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", err
+	}
+	d.filePath = path
+	return path, nil
+}
+
+// BeginDownloadSession marks the start of a new acquisition run in the log.
+func BeginDownloadSession(label string) {
+	ts := time.Now().Format("2006-01-02 15:04:05")
+	downloadLog.mu.Lock()
+	defer downloadLog.mu.Unlock()
+	downloadLog.appendLocked(fmt.Sprintf("=== %s — %s ===", ts, label))
+}
+
+// DownloadLogText returns the captured log lines joined for display.
+func DownloadLogText() string {
+	downloadLog.mu.Lock()
+	defer downloadLog.mu.Unlock()
+	if len(downloadLog.lines) == 0 {
+		return ""
+	}
+	return strings.Join(downloadLog.lines, "\n")
+}
+
+// DownloadLogLines returns a copy of captured log lines.
+func DownloadLogLines() []string {
+	downloadLog.mu.Lock()
+	defer downloadLog.mu.Unlock()
+	out := make([]string, len(downloadLog.lines))
+	copy(out, downloadLog.lines)
+	return out
+}
+
+// LoadDownloadLog reads the tail of the on-disk download log into memory when the
+// in-memory buffer is empty.
+func LoadDownloadLog() error {
+	downloadLog.mu.Lock()
+	defer downloadLog.mu.Unlock()
+	if len(downloadLog.lines) > 0 {
+		return nil
+	}
+	path, err := downloadLog.resolveFilePathLocked()
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	var tail []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		tail = append(tail, sc.Text())
+		if len(tail) > defaultMaxDownloadLogLines {
+			tail = tail[1:]
+		}
+	}
+	downloadLog.lines = tail
+	return sc.Err()
+}
+
+// DownloadLogPath returns ~/.config/shadowbox/download.log (or platform equivalent).
+func DownloadLogPath() (string, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "shadowbox", "download.log"), nil
+}

--- a/internal/log/capture.go
+++ b/internal/log/capture.go
@@ -125,7 +125,7 @@ func LoadDownloadLog() error {
 		}
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var tail []string
 	sc := bufio.NewScanner(f)

--- a/internal/log/capture_test.go
+++ b/internal/log/capture_test.go
@@ -1,0 +1,73 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDownloadLogCaptureAndSession(t *testing.T) {
+	orig := downloadLog
+	t.Cleanup(func() { downloadLog = orig })
+
+	dir := t.TempDir()
+	downloadLog = &DownloadLog{maxLines: 10, filePath: filepath.Join(dir, "download.log")}
+
+	if _, err := downloadLog.Write([]byte("[STEP] starting\n")); err != nil {
+		t.Fatal(err)
+	}
+	BeginDownloadSession("Downloading")
+	if _, err := downloadLog.Write([]byte("[SYSTEM] yt-dlp test\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	text := DownloadLogText()
+	if !strings.Contains(text, "Downloading") {
+		t.Errorf("missing session header: %q", text)
+	}
+	if !strings.Contains(text, "yt-dlp test") {
+		t.Errorf("missing log line: %q", text)
+	}
+
+	data, err := os.ReadFile(downloadLog.filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "yt-dlp test") {
+		t.Errorf("file missing log line: %q", data)
+	}
+}
+
+func TestDownloadLogMaxLines(t *testing.T) {
+	d := &DownloadLog{maxLines: 3, filePath: filepath.Join(t.TempDir(), "download.log")}
+	for range 5 {
+		_, _ = d.Write([]byte("line\n"))
+	}
+	d.mu.Lock()
+	n := len(d.lines)
+	d.mu.Unlock()
+	if n != 3 {
+		t.Fatalf("got %d lines, want 3", n)
+	}
+}
+
+func TestLoadDownloadLogFromFile(t *testing.T) {
+	orig := downloadLog
+	t.Cleanup(func() { downloadLog = orig })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "download.log")
+	if err := os.WriteFile(path, []byte("older\nnewer\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	downloadLog = &DownloadLog{maxLines: 100, filePath: path}
+
+	if err := LoadDownloadLog(); err != nil {
+		t.Fatal(err)
+	}
+	lines := DownloadLogLines()
+	if len(lines) != 2 || lines[1] != "newer" {
+		t.Fatalf("got %v", lines)
+	}
+}

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,9 @@
+// Package progress defines structured pipeline progress updates for the UI.
+package progress
+
+// Update describes a single pipeline stage, optionally with numeric position.
+type Update struct {
+	Stage   string
+	Current int // 1-based; 0 when unknown
+	Total   int // 0 when unknown
+}

--- a/internal/tag/flac.go
+++ b/internal/tag/flac.go
@@ -97,6 +97,15 @@ func readFLAC(path string) (*Metadata, error) {
 		m.Date = get(flacvorbis.FIELD_DATE)
 		m.Genre = get(flacvorbis.FIELD_GENRE)
 		m.TrackNumber = get(flacvorbis.FIELD_TRACKNUMBER)
+		if m.TrackNumber == "" {
+			m.TrackNumber = get("TRACK")
+		}
+		m.TotalTracks = get("TRACKTOTAL")
+		m.DiscNumber = get("DISCNUMBER")
+		if m.DiscNumber == "" {
+			m.DiscNumber = get("DISC")
+		}
+		m.TotalDiscs = get("DISCTOTAL")
 	}
 	return m, nil
 }

--- a/internal/tag/metadata.go
+++ b/internal/tag/metadata.go
@@ -78,6 +78,15 @@ func Read(path string) (*Metadata, error) {
 	}
 }
 
+// splitSlashPair splits ID3/Vorbis "n/total" values into separate parts.
+func splitSlashPair(raw string) (n, total string) {
+	raw = strings.TrimSpace(raw)
+	if i := strings.IndexByte(raw, '/'); i >= 0 {
+		return strings.TrimSpace(raw[:i]), strings.TrimSpace(raw[i+1:])
+	}
+	return raw, ""
+}
+
 func ext(path string) string {
 	return strings.ToLower(filepath.Ext(path))
 }

--- a/internal/tag/mp3.go
+++ b/internal/tag/mp3.go
@@ -2,6 +2,7 @@ package tag
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bogem/id3v2/v2"
 )
@@ -90,6 +91,36 @@ func readMP3(path string) (*Metadata, error) {
 	if frames := t.GetFrames(t.CommonID("Band/Orchestra/Accompaniment")); len(frames) > 0 {
 		if tf, ok := frames[0].(id3v2.TextFrame); ok {
 			m.AlbumArtist = tf.Text
+		}
+	}
+	if frames := t.GetFrames(t.CommonID("Track number/Position in set")); len(frames) > 0 {
+		if tf, ok := frames[0].(id3v2.TextFrame); ok {
+			m.TrackNumber, m.TotalTracks = splitSlashPair(tf.Text)
+		}
+	}
+	if frames := t.GetFrames(t.CommonID("Part of a set")); len(frames) > 0 {
+		if tf, ok := frames[0].(id3v2.TextFrame); ok {
+			m.DiscNumber, m.TotalDiscs = splitSlashPair(tf.Text)
+		}
+	}
+	for _, frame := range t.GetFrames("TXXX") {
+		uf, ok := frame.(id3v2.UserDefinedTextFrame)
+		if !ok {
+			continue
+		}
+		switch strings.ToUpper(uf.Description) {
+		case "TRACKTOTAL":
+			if m.TotalTracks == "" {
+				m.TotalTracks = uf.Value
+			}
+		case "DISCTOTAL":
+			if m.TotalDiscs == "" {
+				m.TotalDiscs = uf.Value
+			}
+		case "DISCNUMBER":
+			if m.DiscNumber == "" {
+				m.DiscNumber = uf.Value
+			}
 		}
 	}
 	return m, nil

--- a/internal/tag/opus.go
+++ b/internal/tag/opus.go
@@ -188,11 +188,11 @@ func applyVorbisComment(m *Metadata, comment string) {
 		m.Date = val
 	case "GENRE":
 		m.Genre = val
-	case "TRACKNUMBER":
+	case "TRACKNUMBER", "TRACK":
 		m.TrackNumber = val
 	case "TRACKTOTAL":
 		m.TotalTracks = val
-	case "DISCNUMBER":
+	case "DISCNUMBER", "DISC":
 		m.DiscNumber = val
 	case "DISCTOTAL":
 		m.TotalDiscs = val

--- a/internal/tag/read_kh_test.go
+++ b/internal/tag/read_kh_test.go
@@ -1,0 +1,41 @@
+package tag
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadKHInsiderEmbeddedTags(t *testing.T) {
+	if _, err := exec.LookPath("yt-dlp"); err != nil {
+		t.Skip("yt-dlp not available")
+	}
+	dir := t.TempDir()
+	mp3 := "https://jetta.vgmtreasurechest.com/soundtracks/kirby-and-the-forgotten-land-the-complete-soundtrack-2024/jxlmejhj/1-01.%20Ready%20to%20Go%21.mp3"
+	out := filepath.Join(dir, "out.%(ext)s")
+	cmd := exec.Command("yt-dlp", "-x", "--audio-format", "opus", "--embed-metadata", "-o", out, mp3)
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("download failed: %v %s", err, outBytes)
+	}
+	files, _ := filepath.Glob(filepath.Join(dir, "out.*"))
+	if len(files) == 0 {
+		t.Fatal("no output file")
+	}
+	m, err := Read(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("metadata: %+v", m)
+	if m.Artist != "Yuuta Ogasawara" {
+		t.Errorf("artist = %q", m.Artist)
+	}
+	if m.Title != "Ready to Go!" {
+		t.Errorf("title = %q", m.Title)
+	}
+	if m.TrackNumber == "" {
+		t.Errorf("track number empty")
+	}
+	if m.DiscNumber == "" {
+		t.Errorf("disc number empty")
+	}
+}

--- a/internal/ui/forms.go
+++ b/internal/ui/forms.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/EnJulian/shadowbox/internal/app"
+	"github.com/EnJulian/shadowbox/internal/progress"
 )
 
 // openInput switches to the text-input screen for the given context.
@@ -43,25 +44,25 @@ func (m model) submitInput(value string) (tea.Model, tea.Cmd) {
 
 	switch m.inputContext {
 	case "search":
-		cmd := m.startTask("Downloading", func(ctx context.Context, report func(string)) error {
+		cmd := m.startTask("Downloading", func(ctx context.Context, report func(progress.Update)) error {
 			opts.Progress = report
 			return a.Run(ctx, value, opts)
 		})
 		return m, cmd
 	case "url":
-		cmd := m.startTask("Downloading", func(ctx context.Context, report func(string)) error {
+		cmd := m.startTask("Downloading", func(ctx context.Context, report func(progress.Update)) error {
 			opts.Progress = report
 			return a.Run(ctx, value, opts)
 		})
 		return m, cmd
 	case "playlist":
-		cmd := m.startTask("Downloading playlist", func(ctx context.Context, report func(string)) error {
+		cmd := m.startTask("Downloading playlist", func(ctx context.Context, report func(progress.Update)) error {
 			opts.Progress = report
 			return a.RunPlaylist(ctx, value, opts)
 		})
 		return m, cmd
 	case "enhance":
-		cmd := m.startTask("Enhancing audio files", func(ctx context.Context, report func(string)) error {
+		cmd := m.startTask("Enhancing audio files", func(ctx context.Context, report func(progress.Update)) error {
 			opts.Progress = report
 			return a.EnhanceDir(ctx, value, true, []string{"opus", "mp3", "m4a", "flac"}, false, opts)
 		})
@@ -87,7 +88,9 @@ func (m model) viewRunning() string {
 	b.WriteString("\n\n")
 	b.WriteString("  " + m.spinner.View() + " " + m.st.accent.Render(m.result) + "\n\n")
 
-	step := m.progress
+	b.WriteString("  " + renderProgressBar(m.progress, m.theme.Accent, m.theme.Muted) + "\n\n")
+
+	step := m.progress.Stage
 	if step == "" {
 		step = "starting up"
 	}

--- a/internal/ui/log_view.go
+++ b/internal/ui/log_view.go
@@ -1,0 +1,129 @@
+package ui
+
+import (
+	"strings"
+	"strconv"
+
+	tea "github.com/charmbracelet/bubbletea"
+	applog "github.com/EnJulian/shadowbox/internal/log"
+)
+
+func (m model) openDownloadLog() (tea.Model, tea.Cmd) {
+	_ = applog.LoadDownloadLog()
+	m.screen = screenDownloadLog
+	m.logLines = applog.DownloadLogLines()
+	m.logScroll = 0
+	if len(m.logLines) == 0 {
+		m.logScroll = 0
+	} else {
+		m.logScroll = maxLogScroll(m.logLines, m.logViewport())
+	}
+	return m, nil
+}
+
+func (m model) updateDownloadLog(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	viewport := m.logViewport()
+	maxScroll := maxLogScroll(m.logLines, viewport)
+
+	switch msg.String() {
+	case "q", "esc":
+		m.screen = screenMenu
+		return m, nil
+	case "up", "k":
+		if m.logScroll > 0 {
+			m.logScroll--
+		}
+	case "down", "j":
+		if m.logScroll < maxScroll {
+			m.logScroll++
+		}
+	case "pgup":
+		m.logScroll = max(0, m.logScroll-viewport)
+	case "pgdown":
+		m.logScroll = min(maxScroll, m.logScroll+viewport)
+	case "home":
+		m.logScroll = 0
+	case "end", "G":
+		m.logScroll = maxScroll
+	case "r":
+		_ = applog.LoadDownloadLog()
+		m.logLines = applog.DownloadLogLines()
+		maxScroll = maxLogScroll(m.logLines, viewport)
+		m.logScroll = maxScroll
+	}
+	return m, nil
+}
+
+func (m model) logViewport() int {
+	h := m.height - 12
+	if h < 5 {
+		return 5
+	}
+	return h
+}
+
+func maxLogScroll(lines []string, viewport int) int {
+	if len(lines) <= viewport {
+		return 0
+	}
+	return len(lines) - viewport
+}
+
+func visibleLogLines(lines []string, viewport, scroll int) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+	maxScroll := maxLogScroll(lines, viewport)
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+	start := scroll
+	end := scroll + viewport
+	if end > len(lines) {
+		end = len(lines)
+	}
+	return lines[start:end]
+}
+
+func (m model) viewDownloadLog() string {
+	var b strings.Builder
+	b.WriteString(m.st.title.Render(banner))
+	b.WriteString("\n\n")
+	b.WriteString("  " + m.st.subtitle.Render("Download log") + "\n\n")
+
+	viewport := m.logViewport()
+	visible := visibleLogLines(m.logLines, viewport, m.logScroll)
+
+	if len(m.logLines) == 0 {
+		b.WriteString("  " + m.st.item.Render("(no download logs yet — run a download first)") + "\n")
+	} else {
+		for _, line := range visible {
+			b.WriteString("  " + m.st.item.Render(line) + "\n")
+		}
+		if len(m.logLines) > viewport {
+			b.WriteString("\n")
+			b.WriteString(m.st.help.Render(
+				"  lines " + strconv.Itoa(m.logScroll+1) + "-" + strconv.Itoa(min(len(m.logLines), m.logScroll+viewport)) +
+					" of " + strconv.Itoa(len(m.logLines)),
+			))
+		}
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(m.st.help.Render("  up/down: scroll   home/end: top/bottom   r: refresh   esc: menu"))
+	return b.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/ui/menu.go
+++ b/internal/ui/menu.go
@@ -35,10 +35,12 @@ func (m model) selectMenu() (tea.Model, tea.Cmd) {
 	case 4:
 		return m.openLibrary()
 	case 5:
+		return m.openDownloadLog()
+	case 6:
 		m.screen = screenSettings
 		m.settingsCursor = 0
 		return m, nil
-	case 6:
+	case 7:
 		return m, tea.Quit
 	}
 	return m, nil

--- a/internal/ui/program.go
+++ b/internal/ui/program.go
@@ -10,6 +10,7 @@ import (
 	"github.com/EnJulian/shadowbox/internal/app"
 	"github.com/EnJulian/shadowbox/internal/config"
 	applog "github.com/EnJulian/shadowbox/internal/log"
+	"github.com/EnJulian/shadowbox/internal/progress"
 )
 
 type screen int
@@ -21,6 +22,7 @@ const (
 	screenSettingEdit
 	screenThemePicker
 	screenLibrary
+	screenDownloadLog
 	screenRunning
 	screenResult
 )
@@ -31,8 +33,8 @@ type taskDoneMsg struct {
 	err     error
 }
 
-// progressMsg carries a human-readable pipeline stage to the running screen.
-type progressMsg string
+// progressMsg carries a pipeline stage update to the running screen.
+type progressMsg progress.Update
 
 type model struct {
 	cfg   *config.Config
@@ -63,12 +65,16 @@ type model struct {
 	lib libState
 
 	// running progress
-	progress   string
-	progressCh chan string
+	progress   progress.Update
+	progressCh chan progress.Update
 
 	// result
 	result    string
 	resultErr error
+
+	// download log viewer
+	logLines  []string
+	logScroll int
 }
 
 var mainMenu = []string{
@@ -77,14 +83,17 @@ var mainMenu = []string{
 	"Download Playlist",
 	"Enhance Existing Files",
 	"Library",
+	"Download Log",
 	"Settings",
 	"Exit",
 }
 
 // runProgram builds and runs the Bubble Tea program.
 func runProgram(cfg *config.Config) error {
-	// Bubble Tea owns the screen; silence direct log writes for the session.
-	applog.SetWriters(io.Discard, io.Discard)
+	capture := applog.DownloadLogWriter()
+	_ = applog.LoadDownloadLog()
+	applog.SetWriters(io.MultiWriter(io.Discard, capture), io.MultiWriter(io.Discard, capture))
+	applog.SetVerbose(true)
 	defer applog.Reset()
 
 	theme := themeByName(cfg.Theme)
@@ -126,14 +135,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case progressMsg:
-		m.progress = string(msg)
+		m.progress = progress.Update(msg)
 		return m, waitForProgress(m.progressCh)
 
 	case taskDoneMsg:
 		m.screen = screenResult
 		m.result = msg.summary
 		m.resultErr = msg.err
-		m.progress = ""
+		m.progress = progress.Update{}
 		return m, nil
 
 	case tea.KeyMsg:
@@ -167,6 +176,8 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updateThemePicker(msg)
 	case screenLibrary:
 		return m.updateLibrary(msg)
+	case screenDownloadLog:
+		return m.updateDownloadLog(msg)
 	case screenResult:
 		// Any key returns to the menu.
 		m.screen = screenMenu
@@ -180,17 +191,18 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // startTask transitions to the running screen and runs fn in the background.
 // fn receives a report callback it can use to surface live stage descriptions
 // on the running screen.
-func (m *model) startTask(label string, fn func(ctx context.Context, report func(string)) error) tea.Cmd {
+func (m *model) startTask(label string, fn func(ctx context.Context, report func(progress.Update)) error) tea.Cmd {
 	m.screen = screenRunning
 	m.result = label
-	m.progress = ""
+	m.progress = progress.Update{}
+	applog.BeginDownloadSession(label)
 
-	ch := make(chan string, 32)
+	ch := make(chan progress.Update, 32)
 	m.progressCh = ch
-	report := func(s string) {
+	report := func(u progress.Update) {
 		// Non-blocking: never let progress reporting stall the pipeline.
 		select {
-		case ch <- s:
+		case ch <- u:
 		default:
 		}
 	}
@@ -210,13 +222,13 @@ func (m *model) startTask(label string, fn func(ctx context.Context, report func
 
 // waitForProgress blocks on the next stage description from the channel and
 // re-subscribes after each one. It stops (returns nil) when the channel closes.
-func waitForProgress(ch chan string) tea.Cmd {
+func waitForProgress(ch chan progress.Update) tea.Cmd {
 	return func() tea.Msg {
-		s, ok := <-ch
+		u, ok := <-ch
 		if !ok {
 			return nil
 		}
-		return progressMsg(s)
+		return progressMsg(u)
 	}
 }
 
@@ -234,6 +246,8 @@ func (m model) View() string {
 		return m.viewThemePicker()
 	case screenLibrary:
 		return m.viewLibrary()
+	case screenDownloadLog:
+		return m.viewDownloadLog()
 	case screenRunning:
 		return m.viewRunning()
 	case screenResult:

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -1,0 +1,36 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/EnJulian/shadowbox/internal/progress"
+)
+
+const progressBarWidth = 24
+
+// renderProgressBar returns a minimal text progress bar. When total is zero the
+// bar shows a light indeterminate fill without a numeric label.
+func renderProgressBar(u progress.Update, accent, muted lipgloss.Color) string {
+	filled := progressBarWidth / 4
+	if u.Total > 0 && u.Current > 0 {
+		current := u.Current
+		if current > u.Total {
+			current = u.Total
+		}
+		filled = (current * progressBarWidth) / u.Total
+	}
+
+	filledStr := lipgloss.NewStyle().Foreground(accent).Render(strings.Repeat("─", filled))
+	emptyStr := lipgloss.NewStyle().Foreground(muted).Render(strings.Repeat("·", progressBarWidth-filled))
+	bar := "[" + filledStr + emptyStr + "]"
+
+	if u.Total > 0 && u.Current > 0 {
+		label := lipgloss.NewStyle().Foreground(muted).Render(
+			fmt.Sprintf(" %d/%d", u.Current, u.Total),
+		)
+		return bar + label
+	}
+	return bar
+}

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -1,0 +1,55 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/EnJulian/shadowbox/internal/progress"
+)
+
+func TestRenderProgressBarNumbered(t *testing.T) {
+	bar := renderProgressBar(progress.Update{Stage: "downloading track", Current: 3, Total: 10}, "14", "245")
+	if !strings.Contains(bar, "3/10") {
+		t.Fatalf("expected numbered label, got %q", bar)
+	}
+	if !strings.Contains(bar, "[") || !strings.Contains(bar, "]") {
+		t.Fatalf("expected bar brackets, got %q", bar)
+	}
+}
+
+func TestRenderProgressBarIndeterminate(t *testing.T) {
+	bar := renderProgressBar(progress.Update{Stage: "ripping audio"}, "14", "245")
+	if strings.Contains(bar, "/") {
+		t.Fatalf("indeterminate bar should not show fraction, got %q", bar)
+	}
+}
+
+func TestViewRunningPleaseHold(t *testing.T) {
+	m := newTestModel()
+	m.screen = screenRunning
+	m.result = "Downloading"
+	m.progress = progress.Update{Stage: "ripping audio"}
+
+	view := m.viewRunning()
+	if !strings.Contains(view, "please hold") {
+		t.Fatalf("expected please hold, got %q", view)
+	}
+	if strings.Contains(strings.ToLower(view), "wait") {
+		t.Fatalf("should not contain wait text, got %q", view)
+	}
+}
+
+func TestViewRunningProgressBar(t *testing.T) {
+	m := newTestModel()
+	m.screen = screenRunning
+	m.result = "Downloading playlist"
+	m.progress = progress.Update{Stage: "downloading track", Current: 2, Total: 5}
+
+	view := m.viewRunning()
+	if !strings.Contains(view, "2/5") {
+		t.Fatalf("expected numbered progress, got %q", view)
+	}
+	if !strings.Contains(view, "downloading track") {
+		t.Fatalf("expected stage label, got %q", view)
+	}
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -48,8 +48,8 @@ func TestMenuRendersAllScreens(t *testing.T) {
 		t.Error("menu missing first item")
 	}
 
-	// Navigate to Settings (index 5) and open it.
-	for i := 0; i < 5; i++ {
+	// Navigate to Settings (index 6) and open it.
+	for i := 0; i < 6; i++ {
 		next, _ := m.updateMenu(key("down"))
 		m = next.(model)
 	}
@@ -100,5 +100,14 @@ func TestInputAndLibraryViews(t *testing.T) {
 	}
 	if v := m.viewLibrary(); !strings.Contains(v, "Artists") {
 		t.Errorf("library view missing breadcrumb: %q", v)
+	}
+
+	next, _ = m.openDownloadLog()
+	m = next.(model)
+	if m.screen != screenDownloadLog {
+		t.Fatalf("expected download log screen, got %v", m.screen)
+	}
+	if !strings.Contains(m.viewDownloadLog(), "Download log") {
+		t.Error("download log view missing title")
 	}
 }


### PR DESCRIPTION
## Summary
- Add KHInsider track and album download by scraping mirror links and passing them to yt-dlp
- Add minimal numbered progress bar on the TUI running screen for playlist and batch runs
- Add Download Log menu with persisted session output and embedded KHInsider tag support

## Test plan
- [x] `go test ./...` passes
- [x] Download a KHInsider single track and full album from the TUI
- [x] Verify playlist progress bar shows N/M during download
- [x] Open Download Log and confirm recent session output appears