### PR TITLE
[SHB-005] Feature: Add Windows Scoop Install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Personal access token with write access to the EnJulian/homebrew-shadowbox tap.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          # Personal access token with write access to the EnJulian/scoop-shadowbox bucket.
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v2.2.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,6 +98,22 @@ homebrew_casks:
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/shadowbox"]
           end
 
+scoops:
+  - name: shadowbox
+    repository:
+      owner: EnJulian
+      name: scoop-shadowbox
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    homepage: "https://github.com/EnJulian/shadowbox"
+    description: "Music acquisition CLI for YouTube and Bandcamp"
+    license: MIT
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser-bot@users.noreply.github.com
+    depends:
+      - ffmpeg
+      - yt-dlp
+
 release:
   github:
     owner: EnJulian
@@ -114,9 +130,15 @@ release:
     brew install EnJulian/shadowbox
     ```
 
-    ### WinGet (Windows)
+    ### Scoop (Windows)
     ```
-    winget install EnJulian.shadowbox
+    scoop bucket add shadowbox https://github.com/EnJulian/scoop-shadowbox
+    scoop install shadowbox
+    ```
+
+    ### PowerShell (Windows, no Scoop)
+    ```
+    irm https://raw.githubusercontent.com/EnJulian/shadowbox/main/scripts/install.ps1 | iex
     ```
 
     ### Manual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Windows installation via Scoop bucket (`EnJulian/scoop-shadowbox`) and a
+  PowerShell install script (`scripts/install.ps1`); GoReleaser publishes the
+  Scoop manifest on each release alongside the Homebrew cask.
 - KHInsider support: download single tracks and full albums from
   `downloads.khinsider.com` by resolving mirror links and converting via yt-dlp
   (opus, flac, mp3, and other formats). Uses KHInsider album metadata and cover

--- a/README.md
+++ b/README.md
@@ -18,12 +18,20 @@ Needs `yt-dlp` and `ffmpeg` on your `PATH` (`aria2` optional). Run
 # macOS / Linux
 brew tap EnJulian/shadowbox && brew install shadowbox
 
-# Windows
-winget install EnJulian.shadowbox
-
 # From source
 go install github.com/EnJulian/shadowbox/cmd/shadowbox@latest
 ```
+
+```powershell
+# Windows (Scoop — includes ffmpeg and yt-dlp)
+scoop bucket add shadowbox https://github.com/EnJulian/scoop-shadowbox
+scoop install shadowbox
+
+# Windows (PowerShell — no Scoop)
+irm https://raw.githubusercontent.com/EnJulian/shadowbox/main/scripts/install.ps1 | iex
+```
+
+See [docs/INSTALL_WINDOWS.md](docs/INSTALL_WINDOWS.md) for version pinning and manual install.
 
 
 
@@ -53,6 +61,7 @@ override it. Optional — Shadowbox falls back to iTunes and Last.fm without the
 
 ## Docs
 
+- [Install on Windows](docs/INSTALL_WINDOWS.md)
 - [Install from source](docs/INSTALL_FROM_SOURCE.md)
 - [Testing & releasing](docs/RELEASING.md)
 - [Security overview (beginner's guide)](docs/SECURITY_OVERVIEW.md)

--- a/docs/INSTALL_FROM_SOURCE.md
+++ b/docs/INSTALL_FROM_SOURCE.md
@@ -1,7 +1,7 @@
 # Installing Shadowbox from source
 
 This guide covers building and running Shadowbox locally — useful for testing
-before (or instead of) installing through Homebrew or WinGet.
+before (or instead of) installing through Homebrew or Scoop.
 
 For releasing, see [RELEASING.md](RELEASING.md).
 

--- a/docs/INSTALL_WINDOWS.md
+++ b/docs/INSTALL_WINDOWS.md
@@ -1,0 +1,61 @@
+# Installing Shadowbox on Windows
+
+Shadowbox needs **yt-dlp** and **ffmpeg** on your `PATH` (`aria2` is optional).
+Run `shadowbox doctor` after installing to verify.
+
+## Scoop (recommended)
+
+Installs Shadowbox plus its runtime dependencies in one step:
+
+```powershell
+scoop bucket add shadowbox https://github.com/EnJulian/scoop-shadowbox
+scoop install shadowbox
+```
+
+Optional faster downloads:
+
+```powershell
+scoop install aria2
+```
+
+Upgrade later with `scoop update shadowbox`.
+
+## PowerShell (no Scoop)
+
+Downloads the latest release from GitHub, verifies the SHA256 checksum, and
+installs `shadowbox.exe` to `%LOCALAPPDATA%\Programs\Shadowbox`:
+
+```powershell
+irm https://raw.githubusercontent.com/EnJulian/shadowbox/main/scripts/install.ps1 | iex
+```
+
+Install a specific version:
+
+```powershell
+$env:SHADOWBOX_VERSION = 'v1.3.0'
+irm https://raw.githubusercontent.com/EnJulian/shadowbox/main/scripts/install.ps1 | iex
+```
+
+Or download the script and pass `-Version` directly:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/EnJulian/shadowbox/main/scripts/install.ps1 -OutFile install.ps1
+.\install.ps1 -Version v1.3.0
+```
+
+You must install **yt-dlp** and **ffmpeg** yourself (e.g. from
+[yt-dlp releases](https://github.com/yt-dlp/yt-dlp/releases) and
+[ffmpeg builds](https://www.gyan.dev/ffmpeg/builds/)), or switch to Scoop.
+
+## Manual
+
+Download `shadowbox-windows-amd64.zip` from
+[GitHub Releases](https://github.com/EnJulian/shadowbox/releases), extract
+`shadowbox.exe`, and place it on your `PATH`.
+
+Verify the download with the signed `checksums.txt` on the release page — see
+[RELEASING.md](RELEASING.md#verifying-downloads).
+
+## From source
+
+See [INSTALL_FROM_SOURCE.md](INSTALL_FROM_SOURCE.md) if you want to build with Go.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -72,11 +72,14 @@ signed `v*` tag triggers `.github/workflows/release.yml`, which:
 3. Publishes GitHub build provenance attestations for release artifacts.
 4. Pushes an updated Homebrew **cask** to `EnJulian/homebrew-shadowbox`
   (using the `HOMEBREW_TAP_GITHUB_TOKEN` secret).
+5. Pushes an updated Scoop **manifest** to `EnJulian/scoop-shadowbox`
+  (using the `SCOOP_BUCKET_TOKEN` secret).
 
 Separately, when the GitHub Release is *published*,
 `.github/workflows/winget.yml` opens a pull request against
 `microsoft/winget-pkgs` (using the `WINGET_TOKEN` secret and your
-`EnJulian/winget-pkgs` fork).
+`EnJulian/winget-pkgs` fork). WinGet is optional and not required for Windows
+installs — Scoop is the supported path for now.
 
 ### Required repository secrets
 
@@ -84,7 +87,8 @@ Separately, when the GitHub Release is *published*,
 | Secret                      | Used by              | Token type                                                              |
 | --------------------------- | -------------------- | ----------------------------------------------------------------------- |
 | `HOMEBREW_TAP_GITHUB_TOKEN` | GoReleaser cask push | Fine-grained PAT, Contents: read/write on `EnJulian/homebrew-shadowbox` |
-| `WINGET_TOKEN`              | WinGet PR workflow   | Classic PAT with `public_repo` scope                                    |
+| `SCOOP_BUCKET_TOKEN`        | GoReleaser Scoop push | Fine-grained PAT, Contents: read/write on `EnJulian/scoop-shadowbox`   |
+| `WINGET_TOKEN`              | WinGet PR workflow   | Classic PAT with `public_repo` scope (optional)                        |
 
 
 `GITHUB_TOKEN` is provided automatically by Actions for the release itself.
@@ -307,8 +311,12 @@ brew tap EnJulian/shadowbox
 brew install shadowbox
 shadowbox version
 
-# WinGet (after the winget-pkgs PR merges)
+# WinGet (after the winget-pkgs PR merges; optional)
 winget install EnJulian.shadowbox
+
+# Scoop (Windows — supported)
+scoop bucket add shadowbox https://github.com/EnJulian/scoop-shadowbox
+scoop install shadowbox
 ```
 
 
@@ -318,6 +326,8 @@ winget install EnJulian.shadowbox
 - **Release workflow fails on the Homebrew step** — confirm
 `HOMEBREW_TAP_GITHUB_TOKEN` is set and can write to
 `EnJulian/homebrew-shadowbox`.
+- **Release workflow fails on the Scoop step** — confirm
+`SCOOP_BUCKET_TOKEN` is set and can write to `EnJulian/scoop-shadowbox`.
 - **No WinGet PR appears** — the workflow runs on `release: published` (not
 draft/prerelease). Confirm `WINGET_TOKEN` is set and the
 `EnJulian/winget-pkgs` fork exists. You can also run it manually from the

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -1,0 +1,44 @@
+# Scoop bucket for Shadowbox
+
+Shadowbox is distributed on Windows through a custom Scoop bucket:
+[`EnJulian/scoop-shadowbox`](https://github.com/EnJulian/scoop-shadowbox).
+
+## Installing
+
+```powershell
+scoop bucket add shadowbox https://github.com/EnJulian/scoop-shadowbox
+scoop install shadowbox
+```
+
+This pulls in the required `ffmpeg` and `yt-dlp` packages automatically. Install
+`aria2` separately for faster downloads:
+
+```powershell
+scoop install aria2
+```
+
+## How releases update the bucket
+
+The manifest is generated and pushed automatically by GoReleaser during the
+[release workflow](../../.github/workflows/release.yml). On every `v*` tag,
+GoReleaser:
+
+1. Builds the cross-platform binaries.
+2. Renders `shadowbox.json` with the new version, URL, and checksum.
+3. Commits and pushes it to the bucket repository using the
+   `SCOOP_BUCKET_TOKEN` secret.
+
+## One-time bucket setup
+
+1. Create an empty public repository named `scoop-shadowbox` under the
+   `EnJulian` account.
+2. Create a fine-grained or classic personal access token with `contents: write`
+   permission on that repository.
+3. Add it to the `shadowbox` repository secrets as `SCOOP_BUCKET_TOKEN`.
+
+GoReleaser writes the first manifest on the next tagged release. To backfill an
+existing release without cutting a new tag, run the release workflow manually
+after the secret is set, or push a patch tag.
+
+The manifest GoReleaser produces lives at the bucket repo root as
+`shadowbox.json`; you do not need to edit it by hand.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,146 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Install Shadowbox on Windows from GitHub Releases.
+
+.DESCRIPTION
+  Downloads shadowbox-windows-amd64.zip, verifies its SHA256 against the
+  release checksums.txt, installs shadowbox.exe under %LOCALAPPDATA%\Programs\Shadowbox,
+  and adds that folder to your user PATH.
+
+  Shadowbox still needs yt-dlp and ffmpeg on your PATH — run shadowbox doctor
+  after installing. Scoop users get those automatically via scoop install shadowbox.
+
+.PARAMETER Version
+  Release tag to install (e.g. v1.3.0 or 1.3.0). Defaults to the latest release.
+
+.PARAMETER InstallDir
+  Directory for shadowbox.exe. Defaults to %LOCALAPPDATA%\Programs\Shadowbox.
+
+.EXAMPLE
+  irm https://raw.githubusercontent.com/EnJulian/shadowbox/main/scripts/install.ps1 | iex
+
+.EXAMPLE
+  .\install.ps1 -Version v1.3.0
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\Shadowbox"
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $Version -and $env:SHADOWBOX_VERSION) {
+    $Version = $env:SHADOWBOX_VERSION
+}
+
+$Repo = 'EnJulian/shadowbox'
+$AssetName = 'shadowbox-windows-amd64.zip'
+
+function Resolve-ReleaseTag {
+    param([string]$InputVersion)
+
+    if (-not $InputVersion) {
+        return ""
+    }
+    if ($InputVersion -match '^v') {
+        return $InputVersion
+    }
+    return "v$InputVersion"
+}
+
+function Get-GitHubRelease {
+    param([string]$Tag)
+
+    if ($Tag) {
+        $uri = "https://api.github.com/repos/$Repo/releases/tags/$Tag"
+    } else {
+        $uri = "https://api.github.com/repos/$Repo/releases/latest"
+    }
+
+    return Invoke-RestMethod -Uri $uri -Headers @{ 'User-Agent' = 'shadowbox-installer' }
+}
+
+function Get-ExpectedSha256 {
+    param(
+        [string]$ChecksumsPath,
+        [string]$FileName
+    )
+
+    foreach ($line in Get-Content -Path $ChecksumsPath) {
+        if ($line -match '^\s*([a-f0-9]{64})\s+(.+)\s*$') {
+            if ($Matches[2].Trim() -eq $FileName) {
+                return $Matches[1].ToLowerInvariant()
+            }
+        }
+    }
+
+    throw "checksums.txt does not list $FileName."
+}
+
+$tag = Resolve-ReleaseTag -InputVersion $Version
+Write-Host "Fetching release metadata..."
+$release = Get-GitHubRelease -Tag $tag
+$tag = $release.tag_name
+Write-Host "Installing Shadowbox $tag"
+
+$asset = $release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+if (-not $asset) {
+    throw "Release $tag has no $AssetName asset."
+}
+
+$checksumsAsset = $release.assets | Where-Object { $_.name -eq 'checksums.txt' } | Select-Object -First 1
+if (-not $checksumsAsset) {
+    throw "Release $tag has no checksums.txt asset."
+}
+
+$tempRoot = Join-Path $env:TEMP ("shadowbox-install-" + [guid]::NewGuid().ToString())
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+try {
+    $zipPath = Join-Path $tempRoot $AssetName
+    $checksumsPath = Join-Path $tempRoot 'checksums.txt'
+
+    Write-Host "Downloading $AssetName..."
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -UseBasicParsing
+
+    Write-Host "Verifying checksum..."
+    Invoke-WebRequest -Uri $checksumsAsset.browser_download_url -OutFile $checksumsPath -UseBasicParsing
+    $expected = Get-ExpectedSha256 -ChecksumsPath $checksumsPath -FileName $AssetName
+    $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) {
+        throw "Checksum mismatch for $AssetName."
+    }
+
+    Write-Host "Extracting..."
+    $extractDir = Join-Path $tempRoot 'extract'
+    Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+    $exe = Get-ChildItem -Path $extractDir -Filter 'shadowbox.exe' -Recurse | Select-Object -First 1
+    if (-not $exe) {
+        throw 'Archive does not contain shadowbox.exe.'
+    }
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    $target = Join-Path $InstallDir 'shadowbox.exe'
+    Copy-Item -Path $exe.FullName -Destination $target -Force
+
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($userPath -notlike "*$InstallDir*") {
+        $newPath = if ($userPath) { "$userPath;$InstallDir" } else { $InstallDir }
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+        $env:Path = "$env:Path;$InstallDir"
+        Write-Host "Added $InstallDir to your user PATH."
+        Write-Host "Open a new terminal if shadowbox is not found yet."
+    }
+
+    Write-Host ""
+    Write-Host "Installed to $target"
+    & $target version
+    Write-Host ""
+    Write-Host "Run 'shadowbox doctor' to check for yt-dlp and ffmpeg."
+    Write-Host "See https://github.com/EnJulian/shadowbox/blob/main/docs/INSTALL_WINDOWS.md"
+} finally {
+    Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- Add GoReleaser Scoop publishing to `EnJulian/scoop-shadowbox` with ffmpeg and yt-dlp dependencies
- Add `scripts/install.ps1` for non-Scoop Windows installs with SHA256 verification and user PATH setup
- Replace WinGet as the primary Windows install path in README and release docs; add `docs/INSTALL_WINDOWS.md`

## Test plan
- [x] Add `SCOOP_BUCKET_TOKEN` repo secret with write access to `EnJulian/scoop-shadowbox`
- [x] On Windows: `scoop bucket add shadowbox https://github.com/EnJulian/scoop-shadowbox` then `scoop install shadowbox`
- [x] On Windows: `irm https://raw.githubusercontent.com/EnJulian/shadowbox/main/scripts/install.ps1 | iex` and run `shadowbox doctor`
- [x] Verify next tagged release updates the Scoop bucket manifest via GoReleaser