### PR TITLE
[SHB-006] Fix: Consolidate Scoop Release Token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Personal access token with write access to the EnJulian/homebrew-shadowbox tap.
+          # PAT with Contents: write on EnJulian/homebrew-shadowbox and EnJulian/scoop-shadowbox.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          # Personal access token with write access to the EnJulian/scoop-shadowbox bucket.
-          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v2.2.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -103,7 +103,7 @@ scoops:
     repository:
       owner: EnJulian
       name: scoop-shadowbox
-      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/EnJulian/shadowbox"
     description: "Music acquisition CLI for YouTube and Bandcamp"
     license: MIT

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -73,7 +73,7 @@ signed `v*` tag triggers `.github/workflows/release.yml`, which:
 4. Pushes an updated Homebrew **cask** to `EnJulian/homebrew-shadowbox`
   (using the `HOMEBREW_TAP_GITHUB_TOKEN` secret).
 5. Pushes an updated Scoop **manifest** to `EnJulian/scoop-shadowbox`
-  (using the `SCOOP_BUCKET_TOKEN` secret).
+  (using the same `HOMEBREW_TAP_GITHUB_TOKEN` secret).
 
 Separately, when the GitHub Release is *published*,
 `.github/workflows/winget.yml` opens a pull request against
@@ -86,8 +86,7 @@ installs — Scoop is the supported path for now.
 
 | Secret                      | Used by              | Token type                                                              |
 | --------------------------- | -------------------- | ----------------------------------------------------------------------- |
-| `HOMEBREW_TAP_GITHUB_TOKEN` | GoReleaser cask push | Fine-grained PAT, Contents: read/write on `EnJulian/homebrew-shadowbox` |
-| `SCOOP_BUCKET_TOKEN`        | GoReleaser Scoop push | Fine-grained PAT, Contents: read/write on `EnJulian/scoop-shadowbox`   |
+| `HOMEBREW_TAP_GITHUB_TOKEN` | GoReleaser Homebrew + Scoop push | Fine-grained PAT, Contents: read/write on `EnJulian/homebrew-shadowbox` **and** `EnJulian/scoop-shadowbox` |
 | `WINGET_TOKEN`              | WinGet PR workflow   | Classic PAT with `public_repo` scope (optional)                        |
 
 
@@ -326,8 +325,10 @@ scoop install shadowbox
 - **Release workflow fails on the Homebrew step** — confirm
 `HOMEBREW_TAP_GITHUB_TOKEN` is set and can write to
 `EnJulian/homebrew-shadowbox`.
-- **Release workflow fails on the Scoop step** — confirm
-`SCOOP_BUCKET_TOKEN` is set and can write to `EnJulian/scoop-shadowbox`.
+- **Release workflow fails on the Scoop step** — the fine-grained PAT behind
+`HOMEBREW_TAP_GITHUB_TOKEN` must include **both** `EnJulian/homebrew-shadowbox`
+and `EnJulian/scoop-shadowbox` with Contents: read/write. A separate
+`SCOOP_BUCKET_TOKEN` is not used.
 - **No WinGet PR appears** — the workflow runs on `release: published` (not
 draft/prerelease). Confirm `WINGET_TOKEN` is set and the
 `EnJulian/winget-pkgs` fork exists. You can also run it manually from the

--- a/packaging/scoop/README.md
+++ b/packaging/scoop/README.md
@@ -25,20 +25,21 @@ GoReleaser:
 
 1. Builds the cross-platform binaries.
 2. Renders `shadowbox.json` with the new version, URL, and checksum.
-3. Commits and pushes it to the bucket repository using the
-   `SCOOP_BUCKET_TOKEN` secret.
+3. Commits and pushes it to the bucket repository using
+   `HOMEBREW_TAP_GITHUB_TOKEN` (the same PAT as the Homebrew tap).
 
 ## One-time bucket setup
 
 1. Create an empty public repository named `scoop-shadowbox` under the
    `EnJulian` account.
-2. Create a fine-grained or classic personal access token with `contents: write`
-   permission on that repository.
-3. Add it to the `shadowbox` repository secrets as `SCOOP_BUCKET_TOKEN`.
+2. Extend the fine-grained PAT used for `HOMEBREW_TAP_GITHUB_TOKEN` so it has
+   **Contents: read/write** on **both** `EnJulian/homebrew-shadowbox` and
+   `EnJulian/scoop-shadowbox`.
+3. No separate Scoop secret is required.
 
 GoReleaser writes the first manifest on the next tagged release. To backfill an
-existing release without cutting a new tag, run the release workflow manually
-after the secret is set, or push a patch tag.
+existing release without cutting a new tag, update `shadowbox.json` in the
+bucket manually or push a patch tag.
 
 The manifest GoReleaser produces lives at the bucket repo root as
 `shadowbox.json`; you do not need to edit it by hand.


### PR DESCRIPTION
## Summary
- Route GoReleaser Scoop publishing through `HOMEBREW_TAP_GITHUB_TOKEN` instead of a separate `SCOOP_BUCKET_TOKEN`
- Document that the fine-grained PAT must include both `EnJulian/homebrew-shadowbox` and `EnJulian/scoop-shadowbox` with Contents read/write
- Fixes v1.4.0 release failure: `403 Resource not accessible by personal access token` on the Scoop bucket push

## Test plan
- [ ] Extend the fine-grained PAT behind `HOMEBREW_TAP_GITHUB_TOKEN` to include `EnJulian/scoop-shadowbox`
- [ ] Remove unused `SCOOP_BUCKET_TOKEN` repo secret
- [ ] Merge and cut v1.4.1 (or manually update `shadowbox.json` in the bucket to v1.4.0)
- [ ] Confirm release workflow pushes Scoop manifest without 403